### PR TITLE
Add "mtl"

### DIFF
--- a/library/Rebase/Control/Monad/Cont/Class.hs
+++ b/library/Rebase/Control/Monad/Cont/Class.hs
@@ -1,0 +1,7 @@
+module Rebase.Control.Monad.Cont.Class
+(
+  module Control.Monad.Cont.Class,
+)
+where
+
+import Control.Monad.Cont.Class

--- a/library/Rebase/Control/Monad/Error/Class.hs
+++ b/library/Rebase/Control/Monad/Error/Class.hs
@@ -1,0 +1,7 @@
+module Rebase.Control.Monad.Error.Class
+(
+  module Control.Monad.Error.Class,
+)
+where
+
+import Control.Monad.Error.Class

--- a/library/Rebase/Control/Monad/Reader/Class.hs
+++ b/library/Rebase/Control/Monad/Reader/Class.hs
@@ -1,0 +1,7 @@
+module Rebase.Control.Monad.Reader.Class
+(
+  module Control.Monad.Reader.Class,
+)
+where
+
+import Control.Monad.Reader.Class

--- a/library/Rebase/Control/Monad/State/Class.hs
+++ b/library/Rebase/Control/Monad/State/Class.hs
@@ -1,0 +1,7 @@
+module Rebase.Control.Monad.State.Class
+(
+  module Control.Monad.State.Class,
+)
+where
+
+import Control.Monad.State.Class

--- a/library/Rebase/Control/Monad/Writer/Class.hs
+++ b/library/Rebase/Control/Monad/Writer/Class.hs
@@ -1,0 +1,7 @@
+module Rebase.Control.Monad.Writer.Class
+(
+  module Control.Monad.Writer.Class,
+)
+where
+
+import Control.Monad.Writer.Class

--- a/library/Rebase/Prelude.hs
+++ b/library/Rebase/Prelude.hs
@@ -45,12 +45,20 @@ import Rebase.Control.DeepSeq as Exports
 -------------------------
 import Rebase.Control.Monad.IO.Class as Exports
 import Rebase.Control.Monad.Trans.Class as Exports
-import Rebase.Control.Monad.Trans.Cont as Exports hiding (shift)
+import Rebase.Control.Monad.Trans.Cont as Exports hiding (shift, callCC)
 import Rebase.Control.Monad.Trans.Except as Exports (ExceptT(ExceptT), Except, except, runExcept, runExceptT, mapExcept, mapExceptT, withExcept, withExceptT)
 import Rebase.Control.Monad.Trans.Maybe as Exports
 import Rebase.Control.Monad.Trans.Reader as Exports (Reader, runReader, mapReader, withReader, ReaderT(ReaderT), runReaderT, mapReaderT, withReaderT)
 import Rebase.Control.Monad.Trans.State.Strict as Exports (State, runState, evalState, execState, mapState, withState, StateT(StateT), runStateT, evalStateT, execStateT, mapStateT, withStateT)
 import Rebase.Control.Monad.Trans.Writer.Strict as Exports (Writer, runWriter, execWriter, mapWriter, WriterT(..), execWriterT, mapWriterT)
+
+-- mtl
+-------------------------
+import Rebase.Control.Monad.Cont.Class as Exports
+import Rebase.Control.Monad.Error.Class as Exports
+import Rebase.Control.Monad.Reader.Class as Exports
+import Rebase.Control.Monad.State.Class as Exports
+import Rebase.Control.Monad.Writer.Class as Exports
 
 -- either
 -------------------------

--- a/rebase.cabal
+++ b/rebase.cabal
@@ -119,6 +119,12 @@ library
     Rebase.Control.Monad.Trans.State.Strict
     Rebase.Control.Monad.Trans.Writer.Lazy
     Rebase.Control.Monad.Trans.Writer.Strict
+    -- mtl:
+    Rebase.Control.Monad.Cont.Class
+    Rebase.Control.Monad.Error.Class
+    Rebase.Control.Monad.Reader.Class
+    Rebase.Control.Monad.State.Class
+    Rebase.Control.Monad.Writer.Class
     -- either:
     Rebase.Control.Monad.Trans.Either
     Rebase.Data.Either.Combinators
@@ -144,6 +150,7 @@ library
     semigroups >= 0.18 && < 0.19,
     deepseq >= 1.4 && < 2,
     transformers >= 0.4 && < 0.6,
+    mtl >= 2.2 && < 3.0,
     either >= 4.4 && < 5,
     -- general:
     base-prelude >= 0.1.21 && < 0.2,


### PR DESCRIPTION
I added the `mtl` package following these criteria:
- I only added the modules corresponding to the ones already imported from `transformers`;
- I only added the modules corresponding to the classes, as the full modules included imports from `transformers` that were already imported;

The class corresponding to `Except` on `mtl` is `Error`, even if there is an `Except` module that has been recently renamed. I will look later at `free`.

Thanks!
