### PR TITLE
Bump dlist upper bound to 0.9

### DIFF
--- a/rebase.cabal
+++ b/rebase.cabal
@@ -147,7 +147,7 @@ library
     text >= 1 && < 2,
     scientific >= 0.3 && < 0.4,
     uuid == 1.3.*,
-    dlist >= 0.7 && < 0.8,
+    dlist >= 0.7 && < 0.9,
     void >= 0.7 && < 0.8,
     time >= 1.5 && < 2,
     -- control:


### PR DESCRIPTION
I just released [`dlist-0.8`](https://github.com/spl/dlist/releases/tag/v0.8). I didn't test this change to `rebase`, but I don't think it will be break anything.
