### PR TITLE
Expose Data.Kind and GHC.TypeNats

### DIFF
--- a/library/Rebase/Data/Kind.hs
+++ b/library/Rebase/Data/Kind.hs
@@ -1,0 +1,7 @@
+module Rebase.Data.Kind
+(
+  module Data.Kind
+)
+where
+
+import Data.Kind

--- a/library/Rebase/GHC/TypeNats.hs
+++ b/library/Rebase/GHC/TypeNats.hs
@@ -1,0 +1,7 @@
+module Rebase.GHC.TypeNats
+(
+  module GHC.TypeNats
+)
+where
+
+import GHC.TypeNats

--- a/rebase.cabal
+++ b/rebase.cabal
@@ -1,7 +1,7 @@
 name:
   rebase
 version:
-  1.3
+  1.3.1
 synopsis:
   A more progressive alternative to the "base" package
 description:
@@ -205,6 +205,7 @@ library
     Rebase.Data.IORef
     Rebase.Data.Isomorphism
     Rebase.Data.Ix
+    Rebase.Data.Kind
     Rebase.Data.List
     Rebase.Data.List.NonEmpty
     Rebase.Data.List1
@@ -385,6 +386,7 @@ library
     Rebase.GHC.STRef
     Rebase.GHC.TopHandler
     Rebase.GHC.TypeLits
+    Rebase.GHC.TypeNats
     Rebase.GHC.Unicode
     Rebase.GHC.Weak
     Rebase.GHC.Word


### PR DESCRIPTION
I've been using `rerebase` as my Prelude for `ghci` and personal projects for quite a while, but I just ran into the lack of `Data.Kind` when writing my own kinds. If this works for you, I'll open a PR for `rerebase`, too (and squash a version bump in for both).