### PR TITLE
Replace uuid dependency with uuid-types

### DIFF
--- a/library/Rebase/Data/UUID.hs
+++ b/library/Rebase/Data/UUID.hs
@@ -1,7 +1,7 @@
 module Rebase.Data.UUID
 (
-  module Data.UUID
+  module Data.UUID.Types
 )
 where
 
-import Data.UUID
+import Data.UUID.Types

--- a/rebase.cabal
+++ b/rebase.cabal
@@ -439,7 +439,7 @@ library
     time >=1.9 && <1.12,
     transformers >=0.5 && <0.6,
     unordered-containers >=0.2.13 && <0.3,
-    uuid >=1.3 && <1.4,
+    uuid-types >=1.0 && <1.1,
     vector >=0.12 && <0.13,
     vector-instances >=3.4 && <3.5,
     void >=0.7 && <0.8


### PR DESCRIPTION
`Data.UUID` is just a re-export of `Data.UUID.Types`, but with a larger dependency footprint.

This also makes rebase buildable on GHC 9
