### PR TITLE
Use reexports.

### DIFF
--- a/library/Rebase/Control/Applicative.hs
+++ b/library/Rebase/Control/Applicative.hs
@@ -1,6 +1,0 @@
-module Rebase.Control.Applicative
-  ( module Control.Applicative,
-  )
-where
-
-import Control.Applicative

--- a/library/Rebase/Control/Applicative/Backwards.hs
+++ b/library/Rebase/Control/Applicative/Backwards.hs
@@ -1,6 +1,0 @@
-module Rebase.Control.Applicative.Backwards
-  ( module Control.Applicative.Backwards,
-  )
-where
-
-import Control.Applicative.Backwards

--- a/library/Rebase/Control/Applicative/Lift.hs
+++ b/library/Rebase/Control/Applicative/Lift.hs
@@ -1,6 +1,0 @@
-module Rebase.Control.Applicative.Lift
-  ( module Control.Applicative.Lift,
-  )
-where
-
-import Control.Applicative.Lift

--- a/library/Rebase/Control/Arrow.hs
+++ b/library/Rebase/Control/Arrow.hs
@@ -1,6 +1,0 @@
-module Rebase.Control.Arrow
-  ( module Control.Arrow,
-  )
-where
-
-import Control.Arrow

--- a/library/Rebase/Control/Category.hs
+++ b/library/Rebase/Control/Category.hs
@@ -1,6 +1,0 @@
-module Rebase.Control.Category
-  ( module Control.Category,
-  )
-where
-
-import Control.Category

--- a/library/Rebase/Control/Comonad.hs
+++ b/library/Rebase/Control/Comonad.hs
@@ -1,6 +1,0 @@
-module Rebase.Control.Comonad
-  ( module Control.Comonad,
-  )
-where
-
-import Control.Comonad

--- a/library/Rebase/Control/Concurrent.hs
+++ b/library/Rebase/Control/Concurrent.hs
@@ -1,6 +1,0 @@
-module Rebase.Control.Concurrent
-  ( module Control.Concurrent,
-  )
-where
-
-import Control.Concurrent

--- a/library/Rebase/Control/Concurrent/Chan.hs
+++ b/library/Rebase/Control/Concurrent/Chan.hs
@@ -1,6 +1,0 @@
-module Rebase.Control.Concurrent.Chan
-  ( module Control.Concurrent.Chan,
-  )
-where
-
-import Control.Concurrent.Chan

--- a/library/Rebase/Control/Concurrent/MVar.hs
+++ b/library/Rebase/Control/Concurrent/MVar.hs
@@ -1,6 +1,0 @@
-module Rebase.Control.Concurrent.MVar
-  ( module Control.Concurrent.MVar,
-  )
-where
-
-import Control.Concurrent.MVar

--- a/library/Rebase/Control/Concurrent/QSem.hs
+++ b/library/Rebase/Control/Concurrent/QSem.hs
@@ -1,6 +1,0 @@
-module Rebase.Control.Concurrent.QSem
-  ( module Control.Concurrent.QSem,
-  )
-where
-
-import Control.Concurrent.QSem

--- a/library/Rebase/Control/Concurrent/QSemN.hs
+++ b/library/Rebase/Control/Concurrent/QSemN.hs
@@ -1,6 +1,0 @@
-module Rebase.Control.Concurrent.QSemN
-  ( module Control.Concurrent.QSemN,
-  )
-where
-
-import Control.Concurrent.QSemN

--- a/library/Rebase/Control/Concurrent/STM.hs
+++ b/library/Rebase/Control/Concurrent/STM.hs
@@ -1,6 +1,0 @@
-module Rebase.Control.Concurrent.STM
-  ( module Control.Concurrent.STM,
-  )
-where
-
-import Control.Concurrent.STM

--- a/library/Rebase/Control/Concurrent/STM/TArray.hs
+++ b/library/Rebase/Control/Concurrent/STM/TArray.hs
@@ -1,6 +1,0 @@
-module Rebase.Control.Concurrent.STM.TArray
-  ( module Control.Concurrent.STM.TArray,
-  )
-where
-
-import Control.Concurrent.STM.TArray

--- a/library/Rebase/Control/Concurrent/STM/TBQueue.hs
+++ b/library/Rebase/Control/Concurrent/STM/TBQueue.hs
@@ -1,6 +1,0 @@
-module Rebase.Control.Concurrent.STM.TBQueue
-  ( module Control.Concurrent.STM.TBQueue,
-  )
-where
-
-import Control.Concurrent.STM.TBQueue

--- a/library/Rebase/Control/Concurrent/STM/TChan.hs
+++ b/library/Rebase/Control/Concurrent/STM/TChan.hs
@@ -1,6 +1,0 @@
-module Rebase.Control.Concurrent.STM.TChan
-  ( module Control.Concurrent.STM.TChan,
-  )
-where
-
-import Control.Concurrent.STM.TChan

--- a/library/Rebase/Control/Concurrent/STM/TMVar.hs
+++ b/library/Rebase/Control/Concurrent/STM/TMVar.hs
@@ -1,6 +1,0 @@
-module Rebase.Control.Concurrent.STM.TMVar
-  ( module Control.Concurrent.STM.TMVar,
-  )
-where
-
-import Control.Concurrent.STM.TMVar

--- a/library/Rebase/Control/Concurrent/STM/TQueue.hs
+++ b/library/Rebase/Control/Concurrent/STM/TQueue.hs
@@ -1,6 +1,0 @@
-module Rebase.Control.Concurrent.STM.TQueue
-  ( module Control.Concurrent.STM.TQueue,
-  )
-where
-
-import Control.Concurrent.STM.TQueue

--- a/library/Rebase/Control/Concurrent/STM/TSem.hs
+++ b/library/Rebase/Control/Concurrent/STM/TSem.hs
@@ -1,6 +1,0 @@
-module Rebase.Control.Concurrent.STM.TSem
-  ( module Control.Concurrent.STM.TSem,
-  )
-where
-
-import Control.Concurrent.STM.TSem

--- a/library/Rebase/Control/Concurrent/STM/TVar.hs
+++ b/library/Rebase/Control/Concurrent/STM/TVar.hs
@@ -1,6 +1,0 @@
-module Rebase.Control.Concurrent.STM.TVar
-  ( module Control.Concurrent.STM.TVar,
-  )
-where
-
-import Control.Concurrent.STM.TVar

--- a/library/Rebase/Control/DeepSeq.hs
+++ b/library/Rebase/Control/DeepSeq.hs
@@ -1,6 +1,0 @@
-module Rebase.Control.DeepSeq
-  ( module Control.DeepSeq,
-  )
-where
-
-import Control.DeepSeq

--- a/library/Rebase/Control/Exception.hs
+++ b/library/Rebase/Control/Exception.hs
@@ -1,6 +1,0 @@
-module Rebase.Control.Exception
-  ( module Control.Exception,
-  )
-where
-
-import Control.Exception

--- a/library/Rebase/Control/Exception/Base.hs
+++ b/library/Rebase/Control/Exception/Base.hs
@@ -1,6 +1,0 @@
-module Rebase.Control.Exception.Base
-  ( module Control.Exception.Base,
-  )
-where
-
-import Control.Exception.Base

--- a/library/Rebase/Control/Monad.hs
+++ b/library/Rebase/Control/Monad.hs
@@ -1,6 +1,0 @@
-module Rebase.Control.Monad
-  ( module Control.Monad,
-  )
-where
-
-import Control.Monad

--- a/library/Rebase/Control/Monad/Cont.hs
+++ b/library/Rebase/Control/Monad/Cont.hs
@@ -1,6 +1,0 @@
-module Rebase.Control.Monad.Cont
-  ( module Control.Monad.Cont,
-  )
-where
-
-import Control.Monad.Cont

--- a/library/Rebase/Control/Monad/Cont/Class.hs
+++ b/library/Rebase/Control/Monad/Cont/Class.hs
@@ -1,6 +1,0 @@
-module Rebase.Control.Monad.Cont.Class
-  ( module Control.Monad.Cont.Class,
-  )
-where
-
-import Control.Monad.Cont.Class

--- a/library/Rebase/Control/Monad/Error/Class.hs
+++ b/library/Rebase/Control/Monad/Error/Class.hs
@@ -1,6 +1,0 @@
-module Rebase.Control.Monad.Error.Class
-  ( module Control.Monad.Error.Class,
-  )
-where
-
-import Control.Monad.Error.Class

--- a/library/Rebase/Control/Monad/Fail.hs
+++ b/library/Rebase/Control/Monad/Fail.hs
@@ -1,6 +1,0 @@
-module Rebase.Control.Monad.Fail
-  ( module Control.Monad.Fail,
-  )
-where
-
-import Control.Monad.Fail

--- a/library/Rebase/Control/Monad/Fix.hs
+++ b/library/Rebase/Control/Monad/Fix.hs
@@ -1,6 +1,0 @@
-module Rebase.Control.Monad.Fix
-  ( module Control.Monad.Fix,
-  )
-where
-
-import Control.Monad.Fix

--- a/library/Rebase/Control/Monad/IO/Class.hs
+++ b/library/Rebase/Control/Monad/IO/Class.hs
@@ -1,6 +1,0 @@
-module Rebase.Control.Monad.IO.Class
-  ( module Control.Monad.IO.Class,
-  )
-where
-
-import Control.Monad.IO.Class

--- a/library/Rebase/Control/Monad/Identity.hs
+++ b/library/Rebase/Control/Monad/Identity.hs
@@ -1,6 +1,0 @@
-module Rebase.Control.Monad.Identity
-  ( module Control.Monad.Identity,
-  )
-where
-
-import Control.Monad.Identity

--- a/library/Rebase/Control/Monad/RWS.hs
+++ b/library/Rebase/Control/Monad/RWS.hs
@@ -1,6 +1,0 @@
-module Rebase.Control.Monad.RWS
-  ( module Control.Monad.RWS,
-  )
-where
-
-import Control.Monad.RWS

--- a/library/Rebase/Control/Monad/RWS/Class.hs
+++ b/library/Rebase/Control/Monad/RWS/Class.hs
@@ -1,6 +1,0 @@
-module Rebase.Control.Monad.RWS.Class
-  ( module Control.Monad.RWS.Class,
-  )
-where
-
-import Control.Monad.RWS.Class

--- a/library/Rebase/Control/Monad/RWS/Lazy.hs
+++ b/library/Rebase/Control/Monad/RWS/Lazy.hs
@@ -1,6 +1,0 @@
-module Rebase.Control.Monad.RWS.Lazy
-  ( module Control.Monad.RWS.Lazy,
-  )
-where
-
-import Control.Monad.RWS.Lazy

--- a/library/Rebase/Control/Monad/RWS/Strict.hs
+++ b/library/Rebase/Control/Monad/RWS/Strict.hs
@@ -1,6 +1,0 @@
-module Rebase.Control.Monad.RWS.Strict
-  ( module Control.Monad.RWS.Strict,
-  )
-where
-
-import Control.Monad.RWS.Strict

--- a/library/Rebase/Control/Monad/Reader.hs
+++ b/library/Rebase/Control/Monad/Reader.hs
@@ -1,6 +1,0 @@
-module Rebase.Control.Monad.Reader
-  ( module Control.Monad.Reader,
-  )
-where
-
-import Control.Monad.Reader

--- a/library/Rebase/Control/Monad/Reader/Class.hs
+++ b/library/Rebase/Control/Monad/Reader/Class.hs
@@ -1,6 +1,0 @@
-module Rebase.Control.Monad.Reader.Class
-  ( module Control.Monad.Reader.Class,
-  )
-where
-
-import Control.Monad.Reader.Class

--- a/library/Rebase/Control/Monad/ST.hs
+++ b/library/Rebase/Control/Monad/ST.hs
@@ -1,6 +1,0 @@
-module Rebase.Control.Monad.ST
-  ( module Control.Monad.ST,
-  )
-where
-
-import Control.Monad.ST

--- a/library/Rebase/Control/Monad/ST/Lazy.hs
+++ b/library/Rebase/Control/Monad/ST/Lazy.hs
@@ -1,6 +1,0 @@
-module Rebase.Control.Monad.ST.Lazy
-  ( module Control.Monad.ST.Lazy,
-  )
-where
-
-import Control.Monad.ST.Lazy

--- a/library/Rebase/Control/Monad/ST/Lazy/Unsafe.hs
+++ b/library/Rebase/Control/Monad/ST/Lazy/Unsafe.hs
@@ -1,6 +1,0 @@
-module Rebase.Control.Monad.ST.Lazy.Unsafe
-  ( module Control.Monad.ST.Lazy.Unsafe,
-  )
-where
-
-import Control.Monad.ST.Lazy.Unsafe

--- a/library/Rebase/Control/Monad/ST/Strict.hs
+++ b/library/Rebase/Control/Monad/ST/Strict.hs
@@ -1,6 +1,0 @@
-module Rebase.Control.Monad.ST.Strict
-  ( module Control.Monad.ST.Strict,
-  )
-where
-
-import Control.Monad.ST.Strict

--- a/library/Rebase/Control/Monad/ST/Unsafe.hs
+++ b/library/Rebase/Control/Monad/ST/Unsafe.hs
@@ -1,6 +1,0 @@
-module Rebase.Control.Monad.ST.Unsafe
-  ( module Control.Monad.ST.Unsafe,
-  )
-where
-
-import Control.Monad.ST.Unsafe

--- a/library/Rebase/Control/Monad/STM.hs
+++ b/library/Rebase/Control/Monad/STM.hs
@@ -1,6 +1,0 @@
-module Rebase.Control.Monad.STM
-  ( module Control.Monad.STM,
-  )
-where
-
-import Control.Monad.STM

--- a/library/Rebase/Control/Monad/Signatures.hs
+++ b/library/Rebase/Control/Monad/Signatures.hs
@@ -1,6 +1,0 @@
-module Rebase.Control.Monad.Signatures
-  ( module Control.Monad.Signatures,
-  )
-where
-
-import Control.Monad.Signatures

--- a/library/Rebase/Control/Monad/State.hs
+++ b/library/Rebase/Control/Monad/State.hs
@@ -1,6 +1,0 @@
-module Rebase.Control.Monad.State
-  ( module Control.Monad.State,
-  )
-where
-
-import Control.Monad.State

--- a/library/Rebase/Control/Monad/State/Class.hs
+++ b/library/Rebase/Control/Monad/State/Class.hs
@@ -1,6 +1,0 @@
-module Rebase.Control.Monad.State.Class
-  ( module Control.Monad.State.Class,
-  )
-where
-
-import Control.Monad.State.Class

--- a/library/Rebase/Control/Monad/State/Lazy.hs
+++ b/library/Rebase/Control/Monad/State/Lazy.hs
@@ -1,6 +1,0 @@
-module Rebase.Control.Monad.State.Lazy
-  ( module Control.Monad.State.Lazy,
-  )
-where
-
-import Control.Monad.State.Lazy

--- a/library/Rebase/Control/Monad/State/Strict.hs
+++ b/library/Rebase/Control/Monad/State/Strict.hs
@@ -1,6 +1,0 @@
-module Rebase.Control.Monad.State.Strict
-  ( module Control.Monad.State.Strict,
-  )
-where
-
-import Control.Monad.State.Strict

--- a/library/Rebase/Control/Monad/Trans.hs
+++ b/library/Rebase/Control/Monad/Trans.hs
@@ -1,6 +1,0 @@
-module Rebase.Control.Monad.Trans
-  ( module Control.Monad.Trans,
-  )
-where
-
-import Control.Monad.Trans

--- a/library/Rebase/Control/Monad/Trans/Class.hs
+++ b/library/Rebase/Control/Monad/Trans/Class.hs
@@ -1,6 +1,0 @@
-module Rebase.Control.Monad.Trans.Class
-  ( module Control.Monad.Trans.Class,
-  )
-where
-
-import Control.Monad.Trans.Class

--- a/library/Rebase/Control/Monad/Trans/Cont.hs
+++ b/library/Rebase/Control/Monad/Trans/Cont.hs
@@ -1,6 +1,0 @@
-module Rebase.Control.Monad.Trans.Cont
-  ( module Control.Monad.Trans.Cont,
-  )
-where
-
-import Control.Monad.Trans.Cont

--- a/library/Rebase/Control/Monad/Trans/Except.hs
+++ b/library/Rebase/Control/Monad/Trans/Except.hs
@@ -1,6 +1,0 @@
-module Rebase.Control.Monad.Trans.Except
-  ( module Control.Monad.Trans.Except,
-  )
-where
-
-import Control.Monad.Trans.Except

--- a/library/Rebase/Control/Monad/Trans/Identity.hs
+++ b/library/Rebase/Control/Monad/Trans/Identity.hs
@@ -1,6 +1,0 @@
-module Rebase.Control.Monad.Trans.Identity
-  ( module Control.Monad.Trans.Identity,
-  )
-where
-
-import Control.Monad.Trans.Identity

--- a/library/Rebase/Control/Monad/Trans/Maybe.hs
+++ b/library/Rebase/Control/Monad/Trans/Maybe.hs
@@ -1,6 +1,0 @@
-module Rebase.Control.Monad.Trans.Maybe
-  ( module Control.Monad.Trans.Maybe,
-  )
-where
-
-import Control.Monad.Trans.Maybe

--- a/library/Rebase/Control/Monad/Trans/RWS.hs
+++ b/library/Rebase/Control/Monad/Trans/RWS.hs
@@ -1,6 +1,0 @@
-module Rebase.Control.Monad.Trans.RWS
-  ( module Control.Monad.Trans.RWS,
-  )
-where
-
-import Control.Monad.Trans.RWS

--- a/library/Rebase/Control/Monad/Trans/RWS/Lazy.hs
+++ b/library/Rebase/Control/Monad/Trans/RWS/Lazy.hs
@@ -1,6 +1,0 @@
-module Rebase.Control.Monad.Trans.RWS.Lazy
-  ( module Control.Monad.Trans.RWS.Lazy,
-  )
-where
-
-import Control.Monad.Trans.RWS.Lazy

--- a/library/Rebase/Control/Monad/Trans/RWS/Strict.hs
+++ b/library/Rebase/Control/Monad/Trans/RWS/Strict.hs
@@ -1,6 +1,0 @@
-module Rebase.Control.Monad.Trans.RWS.Strict
-  ( module Control.Monad.Trans.RWS.Strict,
-  )
-where
-
-import Control.Monad.Trans.RWS.Strict

--- a/library/Rebase/Control/Monad/Trans/Reader.hs
+++ b/library/Rebase/Control/Monad/Trans/Reader.hs
@@ -1,6 +1,0 @@
-module Rebase.Control.Monad.Trans.Reader
-  ( module Control.Monad.Trans.Reader,
-  )
-where
-
-import Control.Monad.Trans.Reader

--- a/library/Rebase/Control/Monad/Trans/State.hs
+++ b/library/Rebase/Control/Monad/Trans/State.hs
@@ -1,6 +1,0 @@
-module Rebase.Control.Monad.Trans.State
-  ( module Control.Monad.Trans.State,
-  )
-where
-
-import Control.Monad.Trans.State

--- a/library/Rebase/Control/Monad/Trans/State/Lazy.hs
+++ b/library/Rebase/Control/Monad/Trans/State/Lazy.hs
@@ -1,6 +1,0 @@
-module Rebase.Control.Monad.Trans.State.Lazy
-  ( module Control.Monad.Trans.State.Lazy,
-  )
-where
-
-import Control.Monad.Trans.State.Lazy

--- a/library/Rebase/Control/Monad/Trans/State/Strict.hs
+++ b/library/Rebase/Control/Monad/Trans/State/Strict.hs
@@ -1,6 +1,0 @@
-module Rebase.Control.Monad.Trans.State.Strict
-  ( module Control.Monad.Trans.State.Strict,
-  )
-where
-
-import Control.Monad.Trans.State.Strict

--- a/library/Rebase/Control/Monad/Trans/Writer.hs
+++ b/library/Rebase/Control/Monad/Trans/Writer.hs
@@ -1,6 +1,0 @@
-module Rebase.Control.Monad.Trans.Writer
-  ( module Control.Monad.Trans.Writer,
-  )
-where
-
-import Control.Monad.Trans.Writer

--- a/library/Rebase/Control/Monad/Trans/Writer/Lazy.hs
+++ b/library/Rebase/Control/Monad/Trans/Writer/Lazy.hs
@@ -1,6 +1,0 @@
-module Rebase.Control.Monad.Trans.Writer.Lazy
-  ( module Control.Monad.Trans.Writer.Lazy,
-  )
-where
-
-import Control.Monad.Trans.Writer.Lazy

--- a/library/Rebase/Control/Monad/Trans/Writer/Strict.hs
+++ b/library/Rebase/Control/Monad/Trans/Writer/Strict.hs
@@ -1,6 +1,0 @@
-module Rebase.Control.Monad.Trans.Writer.Strict
-  ( module Control.Monad.Trans.Writer.Strict,
-  )
-where
-
-import Control.Monad.Trans.Writer.Strict

--- a/library/Rebase/Control/Monad/Writer.hs
+++ b/library/Rebase/Control/Monad/Writer.hs
@@ -1,6 +1,0 @@
-module Rebase.Control.Monad.Writer
-  ( module Control.Monad.Writer,
-  )
-where
-
-import Control.Monad.Writer

--- a/library/Rebase/Control/Monad/Writer/Class.hs
+++ b/library/Rebase/Control/Monad/Writer/Class.hs
@@ -1,6 +1,0 @@
-module Rebase.Control.Monad.Writer.Class
-  ( module Control.Monad.Writer.Class,
-  )
-where
-
-import Control.Monad.Writer.Class

--- a/library/Rebase/Control/Monad/Writer/Lazy.hs
+++ b/library/Rebase/Control/Monad/Writer/Lazy.hs
@@ -1,6 +1,0 @@
-module Rebase.Control.Monad.Writer.Lazy
-  ( module Control.Monad.Writer.Lazy,
-  )
-where
-
-import Control.Monad.Writer.Lazy

--- a/library/Rebase/Control/Monad/Writer/Strict.hs
+++ b/library/Rebase/Control/Monad/Writer/Strict.hs
@@ -1,6 +1,0 @@
-module Rebase.Control.Monad.Writer.Strict
-  ( module Control.Monad.Writer.Strict,
-  )
-where
-
-import Control.Monad.Writer.Strict

--- a/library/Rebase/Control/Monad/Zip.hs
+++ b/library/Rebase/Control/Monad/Zip.hs
@@ -1,6 +1,0 @@
-module Rebase.Control.Monad.Zip
-  ( module Control.Monad.Zip,
-  )
-where
-
-import Control.Monad.Zip

--- a/library/Rebase/Control/Selective.hs
+++ b/library/Rebase/Control/Selective.hs
@@ -1,6 +1,0 @@
-module Rebase.Control.Selective
-  ( module Control.Selective,
-  )
-where
-
-import Control.Selective

--- a/library/Rebase/Control/Selective/Free.hs
+++ b/library/Rebase/Control/Selective/Free.hs
@@ -1,6 +1,0 @@
-module Rebase.Control.Selective.Free
-  ( module Control.Selective.Free,
-  )
-where
-
-import Control.Selective.Free

--- a/library/Rebase/Control/Selective/Multi.hs
+++ b/library/Rebase/Control/Selective/Multi.hs
@@ -1,6 +1,0 @@
-module Rebase.Control.Selective.Multi
-  ( module Control.Selective.Multi,
-  )
-where
-
-import Control.Selective.Multi

--- a/library/Rebase/Control/Selective/Rigid/Free.hs
+++ b/library/Rebase/Control/Selective/Rigid/Free.hs
@@ -1,6 +1,0 @@
-module Rebase.Control.Selective.Rigid.Free
-  ( module Control.Selective.Rigid.Free,
-  )
-where
-
-import Control.Selective.Rigid.Free

--- a/library/Rebase/Control/Selective/Rigid/Freer.hs
+++ b/library/Rebase/Control/Selective/Rigid/Freer.hs
@@ -1,6 +1,0 @@
-module Rebase.Control.Selective.Rigid.Freer
-  ( module Control.Selective.Rigid.Freer,
-  )
-where
-
-import Control.Selective.Rigid.Freer

--- a/library/Rebase/Data/Biapplicative.hs
+++ b/library/Rebase/Data/Biapplicative.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Biapplicative
-  ( module Data.Biapplicative,
-  )
-where
-
-import Data.Biapplicative

--- a/library/Rebase/Data/Bifoldable.hs
+++ b/library/Rebase/Data/Bifoldable.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Bifoldable
-  ( module Data.Bifoldable,
-  )
-where
-
-import Data.Bifoldable

--- a/library/Rebase/Data/Bifunctor/Apply.hs
+++ b/library/Rebase/Data/Bifunctor/Apply.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Bifunctor.Apply
-  ( module Data.Bifunctor.Apply,
-  )
-where
-
-import Data.Bifunctor.Apply

--- a/library/Rebase/Data/Bifunctor/Biff.hs
+++ b/library/Rebase/Data/Bifunctor/Biff.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Bifunctor.Biff
-  ( module Data.Bifunctor.Biff,
-  )
-where
-
-import Data.Bifunctor.Biff

--- a/library/Rebase/Data/Bifunctor/Clown.hs
+++ b/library/Rebase/Data/Bifunctor/Clown.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Bifunctor.Clown
-  ( module Data.Bifunctor.Clown,
-  )
-where
-
-import Data.Bifunctor.Clown

--- a/library/Rebase/Data/Bifunctor/Flip.hs
+++ b/library/Rebase/Data/Bifunctor/Flip.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Bifunctor.Flip
-  ( module Data.Bifunctor.Flip,
-  )
-where
-
-import Data.Bifunctor.Flip

--- a/library/Rebase/Data/Bifunctor/Join.hs
+++ b/library/Rebase/Data/Bifunctor/Join.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Bifunctor.Join
-  ( module Data.Bifunctor.Join,
-  )
-where
-
-import Data.Bifunctor.Join

--- a/library/Rebase/Data/Bifunctor/Joker.hs
+++ b/library/Rebase/Data/Bifunctor/Joker.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Bifunctor.Joker
-  ( module Data.Bifunctor.Joker,
-  )
-where
-
-import Data.Bifunctor.Joker

--- a/library/Rebase/Data/Bifunctor/Product.hs
+++ b/library/Rebase/Data/Bifunctor/Product.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Bifunctor.Product
-  ( module Data.Bifunctor.Product,
-  )
-where
-
-import Data.Bifunctor.Product

--- a/library/Rebase/Data/Bifunctor/Tannen.hs
+++ b/library/Rebase/Data/Bifunctor/Tannen.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Bifunctor.Tannen
-  ( module Data.Bifunctor.Tannen,
-  )
-where
-
-import Data.Bifunctor.Tannen

--- a/library/Rebase/Data/Bifunctor/Wrapped.hs
+++ b/library/Rebase/Data/Bifunctor/Wrapped.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Bifunctor.Wrapped
-  ( module Data.Bifunctor.Wrapped,
-  )
-where
-
-import Data.Bifunctor.Wrapped

--- a/library/Rebase/Data/Bitraversable.hs
+++ b/library/Rebase/Data/Bitraversable.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Bitraversable
-  ( module Data.Bitraversable,
-  )
-where
-
-import Data.Bitraversable

--- a/library/Rebase/Data/Bits.hs
+++ b/library/Rebase/Data/Bits.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Bits
-  ( module Data.Bits,
-  )
-where
-
-import Data.Bits

--- a/library/Rebase/Data/Bool.hs
+++ b/library/Rebase/Data/Bool.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Bool
-  ( module Data.Bool,
-  )
-where
-
-import Data.Bool

--- a/library/Rebase/Data/ByteString.hs
+++ b/library/Rebase/Data/ByteString.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.ByteString
-  ( module Data.ByteString,
-  )
-where
-
-import Data.ByteString

--- a/library/Rebase/Data/ByteString/Builder.hs
+++ b/library/Rebase/Data/ByteString/Builder.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.ByteString.Builder
-  ( module Data.ByteString.Builder,
-  )
-where
-
-import Data.ByteString.Builder

--- a/library/Rebase/Data/ByteString/Builder/Extra.hs
+++ b/library/Rebase/Data/ByteString/Builder/Extra.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.ByteString.Builder.Extra
-  ( module Data.ByteString.Builder.Extra,
-  )
-where
-
-import Data.ByteString.Builder.Extra

--- a/library/Rebase/Data/ByteString/Builder/Internal.hs
+++ b/library/Rebase/Data/ByteString/Builder/Internal.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.ByteString.Builder.Internal
-  ( module Data.ByteString.Builder.Internal,
-  )
-where
-
-import Data.ByteString.Builder.Internal

--- a/library/Rebase/Data/ByteString/Builder/Prim.hs
+++ b/library/Rebase/Data/ByteString/Builder/Prim.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.ByteString.Builder.Prim
-  ( module Data.ByteString.Builder.Prim,
-  )
-where
-
-import Data.ByteString.Builder.Prim

--- a/library/Rebase/Data/ByteString/Builder/Prim/Internal.hs
+++ b/library/Rebase/Data/ByteString/Builder/Prim/Internal.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.ByteString.Builder.Prim.Internal
-  ( module Data.ByteString.Builder.Prim.Internal,
-  )
-where
-
-import Data.ByteString.Builder.Prim.Internal

--- a/library/Rebase/Data/ByteString/Builder/Scientific.hs
+++ b/library/Rebase/Data/ByteString/Builder/Scientific.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.ByteString.Builder.Scientific
-  ( module Data.ByteString.Builder.Scientific,
-  )
-where
-
-import Data.ByteString.Builder.Scientific

--- a/library/Rebase/Data/ByteString/Char8.hs
+++ b/library/Rebase/Data/ByteString/Char8.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.ByteString.Char8
-  ( module Data.ByteString.Char8,
-  )
-where
-
-import Data.ByteString.Char8

--- a/library/Rebase/Data/ByteString/Internal.hs
+++ b/library/Rebase/Data/ByteString/Internal.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.ByteString.Internal
-  ( module Data.ByteString.Internal,
-  )
-where
-
-import Data.ByteString.Internal

--- a/library/Rebase/Data/ByteString/Lazy.hs
+++ b/library/Rebase/Data/ByteString/Lazy.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.ByteString.Lazy
-  ( module Data.ByteString.Lazy,
-  )
-where
-
-import Data.ByteString.Lazy

--- a/library/Rebase/Data/ByteString/Lazy/Char8.hs
+++ b/library/Rebase/Data/ByteString/Lazy/Char8.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.ByteString.Lazy.Char8
-  ( module Data.ByteString.Lazy.Char8,
-  )
-where
-
-import Data.ByteString.Lazy.Char8

--- a/library/Rebase/Data/ByteString/Lazy/Internal.hs
+++ b/library/Rebase/Data/ByteString/Lazy/Internal.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.ByteString.Lazy.Internal
-  ( module Data.ByteString.Lazy.Internal,
-  )
-where
-
-import Data.ByteString.Lazy.Internal

--- a/library/Rebase/Data/ByteString/Short.hs
+++ b/library/Rebase/Data/ByteString/Short.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.ByteString.Short
-  ( module Data.ByteString.Short,
-  )
-where
-
-import Data.ByteString.Short

--- a/library/Rebase/Data/ByteString/Short/Internal.hs
+++ b/library/Rebase/Data/ByteString/Short/Internal.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.ByteString.Short.Internal
-  ( module Data.ByteString.Short.Internal,
-  )
-where
-
-import Data.ByteString.Short.Internal

--- a/library/Rebase/Data/ByteString/Unsafe.hs
+++ b/library/Rebase/Data/ByteString/Unsafe.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.ByteString.Unsafe
-  ( module Data.ByteString.Unsafe,
-  )
-where
-
-import Data.ByteString.Unsafe

--- a/library/Rebase/Data/Char.hs
+++ b/library/Rebase/Data/Char.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Char
-  ( module Data.Char,
-  )
-where
-
-import Data.Char

--- a/library/Rebase/Data/Coerce.hs
+++ b/library/Rebase/Data/Coerce.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Coerce
-  ( module Data.Coerce,
-  )
-where
-
-import Data.Coerce

--- a/library/Rebase/Data/Complex.hs
+++ b/library/Rebase/Data/Complex.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Complex
-  ( module Data.Complex,
-  )
-where
-
-import Data.Complex

--- a/library/Rebase/Data/DList.hs
+++ b/library/Rebase/Data/DList.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.DList
-  ( module Data.DList,
-  )
-where
-
-import Data.DList

--- a/library/Rebase/Data/Data.hs
+++ b/library/Rebase/Data/Data.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Data
-  ( module Data.Data,
-  )
-where
-
-import Data.Data

--- a/library/Rebase/Data/Dynamic.hs
+++ b/library/Rebase/Data/Dynamic.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Dynamic
-  ( module Data.Dynamic,
-  )
-where
-
-import Data.Dynamic

--- a/library/Rebase/Data/Either.hs
+++ b/library/Rebase/Data/Either.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Either
-  ( module Data.Either,
-  )
-where
-
-import Data.Either

--- a/library/Rebase/Data/Either/Combinators.hs
+++ b/library/Rebase/Data/Either/Combinators.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Either.Combinators
-  ( module Data.Either.Combinators,
-  )
-where
-
-import Data.Either.Combinators

--- a/library/Rebase/Data/Either/Validation.hs
+++ b/library/Rebase/Data/Either/Validation.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Either.Validation
-  ( module Data.Either.Validation,
-  )
-where
-
-import Data.Either.Validation

--- a/library/Rebase/Data/Eq.hs
+++ b/library/Rebase/Data/Eq.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Eq
-  ( module Data.Eq,
-  )
-where
-
-import Data.Eq

--- a/library/Rebase/Data/Fixed.hs
+++ b/library/Rebase/Data/Fixed.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Fixed
-  ( module Data.Fixed,
-  )
-where
-
-import Data.Fixed

--- a/library/Rebase/Data/Foldable.hs
+++ b/library/Rebase/Data/Foldable.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Foldable
-  ( module Data.Foldable,
-  )
-where
-
-import Data.Foldable

--- a/library/Rebase/Data/Function.hs
+++ b/library/Rebase/Data/Function.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Function
-  ( module Data.Function,
-  )
-where
-
-import Data.Function

--- a/library/Rebase/Data/Functor.hs
+++ b/library/Rebase/Data/Functor.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Functor
-  ( module Data.Functor,
-  )
-where
-
-import Data.Functor

--- a/library/Rebase/Data/Functor/Alt.hs
+++ b/library/Rebase/Data/Functor/Alt.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Functor.Alt
-  ( module Data.Functor.Alt,
-  )
-where
-
-import Data.Functor.Alt

--- a/library/Rebase/Data/Functor/Apply.hs
+++ b/library/Rebase/Data/Functor/Apply.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Functor.Apply
-  ( module Data.Functor.Apply,
-  )
-where
-
-import Data.Functor.Apply

--- a/library/Rebase/Data/Functor/Bind.hs
+++ b/library/Rebase/Data/Functor/Bind.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Functor.Bind
-  ( module Data.Functor.Bind,
-  )
-where
-
-import Data.Functor.Bind

--- a/library/Rebase/Data/Functor/Bind/Class.hs
+++ b/library/Rebase/Data/Functor/Bind/Class.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Functor.Bind.Class
-  ( module Data.Functor.Bind.Class,
-  )
-where
-
-import Data.Functor.Bind.Class

--- a/library/Rebase/Data/Functor/Bind/Trans.hs
+++ b/library/Rebase/Data/Functor/Bind/Trans.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Functor.Bind.Trans
-  ( module Data.Functor.Bind.Trans,
-  )
-where
-
-import Data.Functor.Bind.Trans

--- a/library/Rebase/Data/Functor/Classes.hs
+++ b/library/Rebase/Data/Functor/Classes.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Functor.Classes
-  ( module Data.Functor.Classes,
-  )
-where
-
-import Data.Functor.Classes

--- a/library/Rebase/Data/Functor/Compose.hs
+++ b/library/Rebase/Data/Functor/Compose.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Functor.Compose
-  ( module Data.Functor.Compose,
-  )
-where
-
-import Data.Functor.Compose

--- a/library/Rebase/Data/Functor/Constant.hs
+++ b/library/Rebase/Data/Functor/Constant.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Functor.Constant
-  ( module Data.Functor.Constant,
-  )
-where
-
-import Data.Functor.Constant

--- a/library/Rebase/Data/Functor/Contravariant.hs
+++ b/library/Rebase/Data/Functor/Contravariant.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Functor.Contravariant
-  ( module Data.Functor.Contravariant,
-  )
-where
-
-import Data.Functor.Contravariant

--- a/library/Rebase/Data/Functor/Contravariant/Compose.hs
+++ b/library/Rebase/Data/Functor/Contravariant/Compose.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Functor.Contravariant.Compose
-  ( module Data.Functor.Contravariant.Compose,
-  )
-where
-
-import Data.Functor.Contravariant.Compose

--- a/library/Rebase/Data/Functor/Contravariant/Divisible.hs
+++ b/library/Rebase/Data/Functor/Contravariant/Divisible.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Functor.Contravariant.Divisible
-  ( module Data.Functor.Contravariant.Divisible,
-  )
-where
-
-import Data.Functor.Contravariant.Divisible

--- a/library/Rebase/Data/Functor/Extend.hs
+++ b/library/Rebase/Data/Functor/Extend.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Functor.Extend
-  ( module Data.Functor.Extend,
-  )
-where
-
-import Data.Functor.Extend

--- a/library/Rebase/Data/Functor/Identity.hs
+++ b/library/Rebase/Data/Functor/Identity.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Functor.Identity
-  ( module Data.Functor.Identity,
-  )
-where
-
-import Data.Functor.Identity

--- a/library/Rebase/Data/Functor/Invariant.hs
+++ b/library/Rebase/Data/Functor/Invariant.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Functor.Invariant
-  ( module Data.Functor.Invariant,
-  )
-where
-
-import Data.Functor.Invariant

--- a/library/Rebase/Data/Functor/Invariant/TH.hs
+++ b/library/Rebase/Data/Functor/Invariant/TH.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Functor.Invariant.TH
-  ( module Data.Functor.Invariant.TH,
-  )
-where
-
-import Data.Functor.Invariant.TH

--- a/library/Rebase/Data/Functor/Plus.hs
+++ b/library/Rebase/Data/Functor/Plus.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Functor.Plus
-  ( module Data.Functor.Plus,
-  )
-where
-
-import Data.Functor.Plus

--- a/library/Rebase/Data/Functor/Product.hs
+++ b/library/Rebase/Data/Functor/Product.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Functor.Product
-  ( module Data.Functor.Product,
-  )
-where
-
-import Data.Functor.Product

--- a/library/Rebase/Data/Functor/Reverse.hs
+++ b/library/Rebase/Data/Functor/Reverse.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Functor.Reverse
-  ( module Data.Functor.Reverse,
-  )
-where
-
-import Data.Functor.Reverse

--- a/library/Rebase/Data/Functor/Sum.hs
+++ b/library/Rebase/Data/Functor/Sum.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Functor.Sum
-  ( module Data.Functor.Sum,
-  )
-where
-
-import Data.Functor.Sum

--- a/library/Rebase/Data/Graph.hs
+++ b/library/Rebase/Data/Graph.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Graph
-  ( module Data.Graph,
-  )
-where
-
-import Data.Graph

--- a/library/Rebase/Data/Group.hs
+++ b/library/Rebase/Data/Group.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Group
-  ( module Data.Group,
-  )
-where
-
-import Data.Group

--- a/library/Rebase/Data/Groupoid.hs
+++ b/library/Rebase/Data/Groupoid.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Groupoid
-  ( module Data.Groupoid,
-  )
-where
-
-import Data.Groupoid

--- a/library/Rebase/Data/HashMap/Lazy.hs
+++ b/library/Rebase/Data/HashMap/Lazy.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.HashMap.Lazy
-  ( module Data.HashMap.Lazy,
-  )
-where
-
-import Data.HashMap.Lazy

--- a/library/Rebase/Data/HashMap/Strict.hs
+++ b/library/Rebase/Data/HashMap/Strict.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.HashMap.Strict
-  ( module Data.HashMap.Strict,
-  )
-where
-
-import Data.HashMap.Strict

--- a/library/Rebase/Data/HashSet.hs
+++ b/library/Rebase/Data/HashSet.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.HashSet
-  ( module Data.HashSet,
-  )
-where
-
-import Data.HashSet

--- a/library/Rebase/Data/Hashable.hs
+++ b/library/Rebase/Data/Hashable.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Hashable
-  ( module Data.Hashable,
-  )
-where
-
-import Data.Hashable

--- a/library/Rebase/Data/IORef.hs
+++ b/library/Rebase/Data/IORef.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.IORef
-  ( module Data.IORef,
-  )
-where
-
-import Data.IORef

--- a/library/Rebase/Data/Int.hs
+++ b/library/Rebase/Data/Int.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Int
-  ( module Data.Int,
-  )
-where
-
-import Data.Int

--- a/library/Rebase/Data/IntMap.hs
+++ b/library/Rebase/Data/IntMap.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.IntMap
-  ( module Data.IntMap,
-  )
-where
-
-import Data.IntMap

--- a/library/Rebase/Data/IntMap/Lazy.hs
+++ b/library/Rebase/Data/IntMap/Lazy.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.IntMap.Lazy
-  ( module Data.IntMap.Lazy,
-  )
-where
-
-import Data.IntMap.Lazy

--- a/library/Rebase/Data/IntMap/Strict.hs
+++ b/library/Rebase/Data/IntMap/Strict.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.IntMap.Strict
-  ( module Data.IntMap.Strict,
-  )
-where
-
-import Data.IntMap.Strict

--- a/library/Rebase/Data/IntSet.hs
+++ b/library/Rebase/Data/IntSet.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.IntSet
-  ( module Data.IntSet,
-  )
-where
-
-import Data.IntSet

--- a/library/Rebase/Data/Isomorphism.hs
+++ b/library/Rebase/Data/Isomorphism.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Isomorphism
-  ( module Data.Isomorphism,
-  )
-where
-
-import Data.Isomorphism

--- a/library/Rebase/Data/Ix.hs
+++ b/library/Rebase/Data/Ix.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Ix
-  ( module Data.Ix,
-  )
-where
-
-import Data.Ix

--- a/library/Rebase/Data/Kind.hs
+++ b/library/Rebase/Data/Kind.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Kind
-  ( module Data.Kind,
-  )
-where
-
-import Data.Kind

--- a/library/Rebase/Data/List.hs
+++ b/library/Rebase/Data/List.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.List
-  ( module Data.List,
-  )
-where
-
-import Data.List

--- a/library/Rebase/Data/List/NonEmpty.hs
+++ b/library/Rebase/Data/List/NonEmpty.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.List.NonEmpty
-  ( module Data.List.NonEmpty,
-  )
-where
-
-import Data.List.NonEmpty

--- a/library/Rebase/Data/Map.hs
+++ b/library/Rebase/Data/Map.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Map
-  ( module Data.Map,
-  )
-where
-
-import Data.Map

--- a/library/Rebase/Data/Map/Lazy.hs
+++ b/library/Rebase/Data/Map/Lazy.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Map.Lazy
-  ( module Data.Map.Lazy,
-  )
-where
-
-import Data.Map.Lazy

--- a/library/Rebase/Data/Map/Strict.hs
+++ b/library/Rebase/Data/Map/Strict.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Map.Strict
-  ( module Data.Map.Strict,
-  )
-where
-
-import Data.Map.Strict

--- a/library/Rebase/Data/Maybe.hs
+++ b/library/Rebase/Data/Maybe.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Maybe
-  ( module Data.Maybe,
-  )
-where
-
-import Data.Maybe

--- a/library/Rebase/Data/Monoid.hs
+++ b/library/Rebase/Data/Monoid.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Monoid
-  ( module Data.Monoid,
-  )
-where
-
-import Data.Monoid

--- a/library/Rebase/Data/Ord.hs
+++ b/library/Rebase/Data/Ord.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Ord
-  ( module Data.Ord,
-  )
-where
-
-import Data.Ord

--- a/library/Rebase/Data/Profunctor.hs
+++ b/library/Rebase/Data/Profunctor.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Profunctor
-  ( module Data.Profunctor,
-  )
-where
-
-import Data.Profunctor

--- a/library/Rebase/Data/Profunctor/Adjunction.hs
+++ b/library/Rebase/Data/Profunctor/Adjunction.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Profunctor.Adjunction
-  ( module Data.Profunctor.Adjunction,
-  )
-where
-
-import Data.Profunctor.Adjunction

--- a/library/Rebase/Data/Profunctor/Cayley.hs
+++ b/library/Rebase/Data/Profunctor/Cayley.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Profunctor.Cayley
-  ( module Data.Profunctor.Cayley,
-  )
-where
-
-import Data.Profunctor.Cayley

--- a/library/Rebase/Data/Profunctor/Choice.hs
+++ b/library/Rebase/Data/Profunctor/Choice.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Profunctor.Choice
-  ( module Data.Profunctor.Choice,
-  )
-where
-
-import Data.Profunctor.Choice

--- a/library/Rebase/Data/Profunctor/Closed.hs
+++ b/library/Rebase/Data/Profunctor/Closed.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Profunctor.Closed
-  ( module Data.Profunctor.Closed,
-  )
-where
-
-import Data.Profunctor.Closed

--- a/library/Rebase/Data/Profunctor/Composition.hs
+++ b/library/Rebase/Data/Profunctor/Composition.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Profunctor.Composition
-  ( module Data.Profunctor.Composition,
-  )
-where
-
-import Data.Profunctor.Composition

--- a/library/Rebase/Data/Profunctor/Mapping.hs
+++ b/library/Rebase/Data/Profunctor/Mapping.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Profunctor.Mapping
-  ( module Data.Profunctor.Mapping,
-  )
-where
-
-import Data.Profunctor.Mapping

--- a/library/Rebase/Data/Profunctor/Monad.hs
+++ b/library/Rebase/Data/Profunctor/Monad.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Profunctor.Monad
-  ( module Data.Profunctor.Monad,
-  )
-where
-
-import Data.Profunctor.Monad

--- a/library/Rebase/Data/Profunctor/Ran.hs
+++ b/library/Rebase/Data/Profunctor/Ran.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Profunctor.Ran
-  ( module Data.Profunctor.Ran,
-  )
-where
-
-import Data.Profunctor.Ran

--- a/library/Rebase/Data/Profunctor/Rep.hs
+++ b/library/Rebase/Data/Profunctor/Rep.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Profunctor.Rep
-  ( module Data.Profunctor.Rep,
-  )
-where
-
-import Data.Profunctor.Rep

--- a/library/Rebase/Data/Profunctor/Sieve.hs
+++ b/library/Rebase/Data/Profunctor/Sieve.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Profunctor.Sieve
-  ( module Data.Profunctor.Sieve,
-  )
-where
-
-import Data.Profunctor.Sieve

--- a/library/Rebase/Data/Profunctor/Strong.hs
+++ b/library/Rebase/Data/Profunctor/Strong.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Profunctor.Strong
-  ( module Data.Profunctor.Strong,
-  )
-where
-
-import Data.Profunctor.Strong

--- a/library/Rebase/Data/Profunctor/Traversing.hs
+++ b/library/Rebase/Data/Profunctor/Traversing.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Profunctor.Traversing
-  ( module Data.Profunctor.Traversing,
-  )
-where
-
-import Data.Profunctor.Traversing

--- a/library/Rebase/Data/Profunctor/Types.hs
+++ b/library/Rebase/Data/Profunctor/Types.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Profunctor.Types
-  ( module Data.Profunctor.Types,
-  )
-where
-
-import Data.Profunctor.Types

--- a/library/Rebase/Data/Profunctor/Unsafe.hs
+++ b/library/Rebase/Data/Profunctor/Unsafe.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Profunctor.Unsafe
-  ( module Data.Profunctor.Unsafe,
-  )
-where
-
-import Data.Profunctor.Unsafe

--- a/library/Rebase/Data/Profunctor/Yoneda.hs
+++ b/library/Rebase/Data/Profunctor/Yoneda.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Profunctor.Yoneda
-  ( module Data.Profunctor.Yoneda,
-  )
-where
-
-import Data.Profunctor.Yoneda

--- a/library/Rebase/Data/Proxy.hs
+++ b/library/Rebase/Data/Proxy.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Proxy
-  ( module Data.Proxy,
-  )
-where
-
-import Data.Proxy

--- a/library/Rebase/Data/Ratio.hs
+++ b/library/Rebase/Data/Ratio.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Ratio
-  ( module Data.Ratio,
-  )
-where
-
-import Data.Ratio

--- a/library/Rebase/Data/STRef.hs
+++ b/library/Rebase/Data/STRef.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.STRef
-  ( module Data.STRef,
-  )
-where
-
-import Data.STRef

--- a/library/Rebase/Data/STRef/Lazy.hs
+++ b/library/Rebase/Data/STRef/Lazy.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.STRef.Lazy
-  ( module Data.STRef.Lazy,
-  )
-where
-
-import Data.STRef.Lazy

--- a/library/Rebase/Data/STRef/Strict.hs
+++ b/library/Rebase/Data/STRef/Strict.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.STRef.Strict
-  ( module Data.STRef.Strict,
-  )
-where
-
-import Data.STRef.Strict

--- a/library/Rebase/Data/Scientific.hs
+++ b/library/Rebase/Data/Scientific.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Scientific
-  ( module Data.Scientific,
-  )
-where
-
-import Data.Scientific

--- a/library/Rebase/Data/Semigroup.hs
+++ b/library/Rebase/Data/Semigroup.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Semigroup
-  ( module Data.Semigroup,
-  )
-where
-
-import Data.Semigroup

--- a/library/Rebase/Data/Semigroup/Bifoldable.hs
+++ b/library/Rebase/Data/Semigroup/Bifoldable.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Semigroup.Bifoldable
-  ( module Data.Semigroup.Bifoldable,
-  )
-where
-
-import Data.Semigroup.Bifoldable

--- a/library/Rebase/Data/Semigroup/Bitraversable.hs
+++ b/library/Rebase/Data/Semigroup/Bitraversable.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Semigroup.Bitraversable
-  ( module Data.Semigroup.Bitraversable,
-  )
-where
-
-import Data.Semigroup.Bitraversable

--- a/library/Rebase/Data/Semigroup/Foldable.hs
+++ b/library/Rebase/Data/Semigroup/Foldable.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Semigroup.Foldable
-  ( module Data.Semigroup.Foldable,
-  )
-where
-
-import Data.Semigroup.Foldable

--- a/library/Rebase/Data/Semigroup/Traversable.hs
+++ b/library/Rebase/Data/Semigroup/Traversable.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Semigroup.Traversable
-  ( module Data.Semigroup.Traversable,
-  )
-where
-
-import Data.Semigroup.Traversable

--- a/library/Rebase/Data/Semigroup/Traversable/Class.hs
+++ b/library/Rebase/Data/Semigroup/Traversable/Class.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Semigroup.Traversable.Class
-  ( module Data.Semigroup.Traversable.Class,
-  )
-where
-
-import Data.Semigroup.Traversable.Class

--- a/library/Rebase/Data/Semigroupoid.hs
+++ b/library/Rebase/Data/Semigroupoid.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Semigroupoid
-  ( module Data.Semigroupoid,
-  )
-where
-
-import Data.Semigroupoid

--- a/library/Rebase/Data/Semigroupoid/Dual.hs
+++ b/library/Rebase/Data/Semigroupoid/Dual.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Semigroupoid.Dual
-  ( module Data.Semigroupoid.Dual,
-  )
-where
-
-import Data.Semigroupoid.Dual

--- a/library/Rebase/Data/Semigroupoid/Ob.hs
+++ b/library/Rebase/Data/Semigroupoid/Ob.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Semigroupoid.Ob
-  ( module Data.Semigroupoid.Ob,
-  )
-where
-
-import Data.Semigroupoid.Ob

--- a/library/Rebase/Data/Semigroupoid/Static.hs
+++ b/library/Rebase/Data/Semigroupoid/Static.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Semigroupoid.Static
-  ( module Data.Semigroupoid.Static,
-  )
-where
-
-import Data.Semigroupoid.Static

--- a/library/Rebase/Data/Sequence.hs
+++ b/library/Rebase/Data/Sequence.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Sequence
-  ( module Data.Sequence,
-  )
-where
-
-import Data.Sequence

--- a/library/Rebase/Data/Set.hs
+++ b/library/Rebase/Data/Set.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Set
-  ( module Data.Set,
-  )
-where
-
-import Data.Set

--- a/library/Rebase/Data/String.hs
+++ b/library/Rebase/Data/String.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.String
-  ( module Data.String,
-  )
-where
-
-import Data.String

--- a/library/Rebase/Data/Text/Array.hs
+++ b/library/Rebase/Data/Text/Array.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Text.Array
-  ( module Data.Text.Array,
-  )
-where
-
-import Data.Text.Array

--- a/library/Rebase/Data/Text/Encoding.hs
+++ b/library/Rebase/Data/Text/Encoding.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Text.Encoding
-  ( module Data.Text.Encoding,
-  )
-where
-
-import Data.Text.Encoding

--- a/library/Rebase/Data/Text/Encoding/Error.hs
+++ b/library/Rebase/Data/Text/Encoding/Error.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Text.Encoding.Error
-  ( module Data.Text.Encoding.Error,
-  )
-where
-
-import Data.Text.Encoding.Error

--- a/library/Rebase/Data/Text/Foreign.hs
+++ b/library/Rebase/Data/Text/Foreign.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Text.Foreign
-  ( module Data.Text.Foreign,
-  )
-where
-
-import Data.Text.Foreign

--- a/library/Rebase/Data/Text/IO.hs
+++ b/library/Rebase/Data/Text/IO.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Text.IO
-  ( module Data.Text.IO,
-  )
-where
-
-import Data.Text.IO

--- a/library/Rebase/Data/Text/Internal.hs
+++ b/library/Rebase/Data/Text/Internal.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Text.Internal
-  ( module Data.Text.Internal,
-  )
-where
-
-import Data.Text.Internal

--- a/library/Rebase/Data/Text/Lazy/Builder.hs
+++ b/library/Rebase/Data/Text/Lazy/Builder.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Text.Lazy.Builder
-  ( module Data.Text.Lazy.Builder,
-  )
-where
-
-import Data.Text.Lazy.Builder

--- a/library/Rebase/Data/Text/Lazy/Builder/Int.hs
+++ b/library/Rebase/Data/Text/Lazy/Builder/Int.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Text.Lazy.Builder.Int
-  ( module Data.Text.Lazy.Builder.Int,
-  )
-where
-
-import Data.Text.Lazy.Builder.Int

--- a/library/Rebase/Data/Text/Lazy/Builder/RealFloat.hs
+++ b/library/Rebase/Data/Text/Lazy/Builder/RealFloat.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Text.Lazy.Builder.RealFloat
-  ( module Data.Text.Lazy.Builder.RealFloat,
-  )
-where
-
-import Data.Text.Lazy.Builder.RealFloat

--- a/library/Rebase/Data/Text/Lazy/Builder/Scientific.hs
+++ b/library/Rebase/Data/Text/Lazy/Builder/Scientific.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Text.Lazy.Builder.Scientific
-  ( module Data.Text.Lazy.Builder.Scientific,
-  )
-where
-
-import Data.Text.Lazy.Builder.Scientific

--- a/library/Rebase/Data/Text/Lazy/Encoding.hs
+++ b/library/Rebase/Data/Text/Lazy/Encoding.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Text.Lazy.Encoding
-  ( module Data.Text.Lazy.Encoding,
-  )
-where
-
-import Data.Text.Lazy.Encoding

--- a/library/Rebase/Data/Text/Lazy/IO.hs
+++ b/library/Rebase/Data/Text/Lazy/IO.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Text.Lazy.IO
-  ( module Data.Text.Lazy.IO,
-  )
-where
-
-import Data.Text.Lazy.IO

--- a/library/Rebase/Data/Text/Lazy/Read.hs
+++ b/library/Rebase/Data/Text/Lazy/Read.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Text.Lazy.Read
-  ( module Data.Text.Lazy.Read,
-  )
-where
-
-import Data.Text.Lazy.Read

--- a/library/Rebase/Data/Text/Read.hs
+++ b/library/Rebase/Data/Text/Read.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Text.Read
-  ( module Data.Text.Read,
-  )
-where
-
-import Data.Text.Read

--- a/library/Rebase/Data/Text/Unsafe.hs
+++ b/library/Rebase/Data/Text/Unsafe.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Text.Unsafe
-  ( module Data.Text.Unsafe,
-  )
-where
-
-import Data.Text.Unsafe

--- a/library/Rebase/Data/Time.hs
+++ b/library/Rebase/Data/Time.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Time
-  ( module Data.Time,
-  )
-where
-
-import Data.Time

--- a/library/Rebase/Data/Time/Calendar.hs
+++ b/library/Rebase/Data/Time/Calendar.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Time.Calendar
-  ( module Data.Time.Calendar,
-  )
-where
-
-import Data.Time.Calendar

--- a/library/Rebase/Data/Time/Calendar/Easter.hs
+++ b/library/Rebase/Data/Time/Calendar/Easter.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Time.Calendar.Easter
-  ( module Data.Time.Calendar.Easter,
-  )
-where
-
-import Data.Time.Calendar.Easter

--- a/library/Rebase/Data/Time/Calendar/Julian.hs
+++ b/library/Rebase/Data/Time/Calendar/Julian.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Time.Calendar.Julian
-  ( module Data.Time.Calendar.Julian,
-  )
-where
-
-import Data.Time.Calendar.Julian

--- a/library/Rebase/Data/Time/Calendar/MonthDay.hs
+++ b/library/Rebase/Data/Time/Calendar/MonthDay.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Time.Calendar.MonthDay
-  ( module Data.Time.Calendar.MonthDay,
-  )
-where
-
-import Data.Time.Calendar.MonthDay

--- a/library/Rebase/Data/Time/Calendar/OrdinalDate.hs
+++ b/library/Rebase/Data/Time/Calendar/OrdinalDate.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Time.Calendar.OrdinalDate
-  ( module Data.Time.Calendar.OrdinalDate,
-  )
-where
-
-import Data.Time.Calendar.OrdinalDate

--- a/library/Rebase/Data/Time/Calendar/WeekDate.hs
+++ b/library/Rebase/Data/Time/Calendar/WeekDate.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Time.Calendar.WeekDate
-  ( module Data.Time.Calendar.WeekDate,
-  )
-where
-
-import Data.Time.Calendar.WeekDate

--- a/library/Rebase/Data/Time/Clock.hs
+++ b/library/Rebase/Data/Time/Clock.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Time.Clock
-  ( module Data.Time.Clock,
-  )
-where
-
-import Data.Time.Clock

--- a/library/Rebase/Data/Time/Clock/POSIX.hs
+++ b/library/Rebase/Data/Time/Clock/POSIX.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Time.Clock.POSIX
-  ( module Data.Time.Clock.POSIX,
-  )
-where
-
-import Data.Time.Clock.POSIX

--- a/library/Rebase/Data/Time/Clock/System.hs
+++ b/library/Rebase/Data/Time/Clock/System.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Time.Clock.System
-  ( module Data.Time.Clock.System,
-  )
-where
-
-import Data.Time.Clock.System

--- a/library/Rebase/Data/Time/Clock/TAI.hs
+++ b/library/Rebase/Data/Time/Clock/TAI.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Time.Clock.TAI
-  ( module Data.Time.Clock.TAI,
-  )
-where
-
-import Data.Time.Clock.TAI

--- a/library/Rebase/Data/Time/Compat.hs
+++ b/library/Rebase/Data/Time/Compat.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Time.Compat
-  ( module Data.Time.Compat,
-  )
-where
-
-import Data.Time.Compat

--- a/library/Rebase/Data/Time/Format.hs
+++ b/library/Rebase/Data/Time/Format.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Time.Format
-  ( module Data.Time.Format,
-  )
-where
-
-import Data.Time.Format

--- a/library/Rebase/Data/Time/Format/ISO8601.hs
+++ b/library/Rebase/Data/Time/Format/ISO8601.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Time.Format.ISO8601
-  ( module Data.Time.Format.ISO8601,
-  )
-where
-
-import Data.Time.Format.ISO8601

--- a/library/Rebase/Data/Time/LocalTime.hs
+++ b/library/Rebase/Data/Time/LocalTime.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Time.LocalTime
-  ( module Data.Time.LocalTime,
-  )
-where
-
-import Data.Time.LocalTime

--- a/library/Rebase/Data/Traversable.hs
+++ b/library/Rebase/Data/Traversable.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Traversable
-  ( module Data.Traversable,
-  )
-where
-
-import Data.Traversable

--- a/library/Rebase/Data/Traversable/Instances.hs
+++ b/library/Rebase/Data/Traversable/Instances.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Traversable.Instances
-  (
-  )
-where
-
-import Data.Traversable.Instances ()

--- a/library/Rebase/Data/Tree.hs
+++ b/library/Rebase/Data/Tree.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Tree
-  ( module Data.Tree,
-  )
-where
-
-import Data.Tree

--- a/library/Rebase/Data/Tuple.hs
+++ b/library/Rebase/Data/Tuple.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Tuple
-  ( module Data.Tuple,
-  )
-where
-
-import Data.Tuple

--- a/library/Rebase/Data/Type/Bool.hs
+++ b/library/Rebase/Data/Type/Bool.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Type.Bool
-  ( module Data.Type.Bool,
-  )
-where
-
-import Data.Type.Bool

--- a/library/Rebase/Data/Type/Coercion.hs
+++ b/library/Rebase/Data/Type/Coercion.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Type.Coercion
-  ( module Data.Type.Coercion,
-  )
-where
-
-import Data.Type.Coercion

--- a/library/Rebase/Data/Type/Equality.hs
+++ b/library/Rebase/Data/Type/Equality.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Type.Equality
-  ( module Data.Type.Equality,
-  )
-where
-
-import Data.Type.Equality

--- a/library/Rebase/Data/Typeable.hs
+++ b/library/Rebase/Data/Typeable.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Typeable
-  ( module Data.Typeable,
-  )
-where
-
-import Data.Typeable

--- a/library/Rebase/Data/UUID.hs
+++ b/library/Rebase/Data/UUID.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.UUID
-  ( module Data.UUID.Types,
-  )
-where
-
-import Data.UUID.Types

--- a/library/Rebase/Data/Unique.hs
+++ b/library/Rebase/Data/Unique.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Unique
-  ( module Data.Unique,
-  )
-where
-
-import Data.Unique

--- a/library/Rebase/Data/Vector.hs
+++ b/library/Rebase/Data/Vector.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Vector
-  ( module Data.Vector,
-  )
-where
-
-import Data.Vector

--- a/library/Rebase/Data/Vector/Fusion/Stream/Monadic.hs
+++ b/library/Rebase/Data/Vector/Fusion/Stream/Monadic.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Vector.Fusion.Stream.Monadic
-  ( module Data.Vector.Fusion.Stream.Monadic,
-  )
-where
-
-import Data.Vector.Fusion.Stream.Monadic

--- a/library/Rebase/Data/Vector/Fusion/Util.hs
+++ b/library/Rebase/Data/Vector/Fusion/Util.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Vector.Fusion.Util
-  ( module Data.Vector.Fusion.Util,
-  )
-where
-
-import Data.Vector.Fusion.Util

--- a/library/Rebase/Data/Vector/Generic.hs
+++ b/library/Rebase/Data/Vector/Generic.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Vector.Generic
-  ( module Data.Vector.Generic,
-  )
-where
-
-import Data.Vector.Generic

--- a/library/Rebase/Data/Vector/Generic/Base.hs
+++ b/library/Rebase/Data/Vector/Generic/Base.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Vector.Generic.Base
-  ( module Data.Vector.Generic.Base,
-  )
-where
-
-import Data.Vector.Generic.Base

--- a/library/Rebase/Data/Vector/Generic/Mutable.hs
+++ b/library/Rebase/Data/Vector/Generic/Mutable.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Vector.Generic.Mutable
-  ( module Data.Vector.Generic.Mutable,
-  )
-where
-
-import Data.Vector.Generic.Mutable

--- a/library/Rebase/Data/Vector/Generic/New.hs
+++ b/library/Rebase/Data/Vector/Generic/New.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Vector.Generic.New
-  ( module Data.Vector.Generic.New,
-  )
-where
-
-import Data.Vector.Generic.New

--- a/library/Rebase/Data/Vector/Instances.hs
+++ b/library/Rebase/Data/Vector/Instances.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Vector.Instances
-  (
-  )
-where
-
-import Data.Vector.Instances ()

--- a/library/Rebase/Data/Vector/Internal/Check.hs
+++ b/library/Rebase/Data/Vector/Internal/Check.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Vector.Internal.Check
-  ( module Data.Vector.Internal.Check,
-  )
-where
-
-import Data.Vector.Internal.Check

--- a/library/Rebase/Data/Vector/Mutable.hs
+++ b/library/Rebase/Data/Vector/Mutable.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Vector.Mutable
-  ( module Data.Vector.Mutable,
-  )
-where
-
-import Data.Vector.Mutable

--- a/library/Rebase/Data/Vector/Primitive.hs
+++ b/library/Rebase/Data/Vector/Primitive.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Vector.Primitive
-  ( module Data.Vector.Primitive,
-  )
-where
-
-import Data.Vector.Primitive

--- a/library/Rebase/Data/Vector/Primitive/Mutable.hs
+++ b/library/Rebase/Data/Vector/Primitive/Mutable.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Vector.Primitive.Mutable
-  ( module Data.Vector.Primitive.Mutable,
-  )
-where
-
-import Data.Vector.Primitive.Mutable

--- a/library/Rebase/Data/Vector/Storable.hs
+++ b/library/Rebase/Data/Vector/Storable.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Vector.Storable
-  ( module Data.Vector.Storable,
-  )
-where
-
-import Data.Vector.Storable

--- a/library/Rebase/Data/Vector/Storable/Internal.hs
+++ b/library/Rebase/Data/Vector/Storable/Internal.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Vector.Storable.Internal
-  ( module Data.Vector.Storable.Internal,
-  )
-where
-
-import Data.Vector.Storable.Internal

--- a/library/Rebase/Data/Vector/Storable/Mutable.hs
+++ b/library/Rebase/Data/Vector/Storable/Mutable.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Vector.Storable.Mutable
-  ( module Data.Vector.Storable.Mutable,
-  )
-where
-
-import Data.Vector.Storable.Mutable

--- a/library/Rebase/Data/Vector/Unboxed.hs
+++ b/library/Rebase/Data/Vector/Unboxed.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Vector.Unboxed
-  ( module Data.Vector.Unboxed,
-  )
-where
-
-import Data.Vector.Unboxed

--- a/library/Rebase/Data/Vector/Unboxed/Base.hs
+++ b/library/Rebase/Data/Vector/Unboxed/Base.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Vector.Unboxed.Base
-  ( module Data.Vector.Unboxed.Base,
-  )
-where
-
-import Data.Vector.Unboxed.Base

--- a/library/Rebase/Data/Vector/Unboxed/Mutable.hs
+++ b/library/Rebase/Data/Vector/Unboxed/Mutable.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Vector.Unboxed.Mutable
-  ( module Data.Vector.Unboxed.Mutable,
-  )
-where
-
-import Data.Vector.Unboxed.Mutable

--- a/library/Rebase/Data/Version.hs
+++ b/library/Rebase/Data/Version.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Version
-  ( module Data.Version,
-  )
-where
-
-import Data.Version

--- a/library/Rebase/Data/Void.hs
+++ b/library/Rebase/Data/Void.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Void
-  ( module Data.Void,
-  )
-where
-
-import Data.Void

--- a/library/Rebase/Data/Void/Unsafe.hs
+++ b/library/Rebase/Data/Void/Unsafe.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Void.Unsafe
-  ( module Data.Void.Unsafe,
-  )
-where
-
-import Data.Void.Unsafe

--- a/library/Rebase/Data/Word.hs
+++ b/library/Rebase/Data/Word.hs
@@ -1,6 +1,0 @@
-module Rebase.Data.Word
-  ( module Data.Word,
-  )
-where
-
-import Data.Word

--- a/library/Rebase/Debug/Trace.hs
+++ b/library/Rebase/Debug/Trace.hs
@@ -1,6 +1,0 @@
-module Rebase.Debug.Trace
-  ( module Debug.Trace,
-  )
-where
-
-import Debug.Trace

--- a/library/Rebase/Foreign.hs
+++ b/library/Rebase/Foreign.hs
@@ -1,6 +1,0 @@
-module Rebase.Foreign
-  ( module Foreign,
-  )
-where
-
-import Foreign

--- a/library/Rebase/Foreign/C.hs
+++ b/library/Rebase/Foreign/C.hs
@@ -1,6 +1,0 @@
-module Rebase.Foreign.C
-  ( module Foreign.C,
-  )
-where
-
-import Foreign.C

--- a/library/Rebase/Foreign/C/Error.hs
+++ b/library/Rebase/Foreign/C/Error.hs
@@ -1,6 +1,0 @@
-module Rebase.Foreign.C.Error
-  ( module Foreign.C.Error,
-  )
-where
-
-import Foreign.C.Error

--- a/library/Rebase/Foreign/C/String.hs
+++ b/library/Rebase/Foreign/C/String.hs
@@ -1,6 +1,0 @@
-module Rebase.Foreign.C.String
-  ( module Foreign.C.String,
-  )
-where
-
-import Foreign.C.String

--- a/library/Rebase/Foreign/C/Types.hs
+++ b/library/Rebase/Foreign/C/Types.hs
@@ -1,6 +1,0 @@
-module Rebase.Foreign.C.Types
-  ( module Foreign.C.Types,
-  )
-where
-
-import Foreign.C.Types

--- a/library/Rebase/Foreign/Concurrent.hs
+++ b/library/Rebase/Foreign/Concurrent.hs
@@ -1,6 +1,0 @@
-module Rebase.Foreign.Concurrent
-  ( module Foreign.Concurrent,
-  )
-where
-
-import Foreign.Concurrent

--- a/library/Rebase/Foreign/ForeignPtr.hs
+++ b/library/Rebase/Foreign/ForeignPtr.hs
@@ -1,6 +1,0 @@
-module Rebase.Foreign.ForeignPtr
-  ( module Foreign.ForeignPtr,
-  )
-where
-
-import Foreign.ForeignPtr

--- a/library/Rebase/Foreign/ForeignPtr/Unsafe.hs
+++ b/library/Rebase/Foreign/ForeignPtr/Unsafe.hs
@@ -1,6 +1,0 @@
-module Rebase.Foreign.ForeignPtr.Unsafe
-  ( module Foreign.ForeignPtr.Unsafe,
-  )
-where
-
-import Foreign.ForeignPtr.Unsafe

--- a/library/Rebase/Foreign/Marshal.hs
+++ b/library/Rebase/Foreign/Marshal.hs
@@ -1,6 +1,0 @@
-module Rebase.Foreign.Marshal
-  ( module Foreign.Marshal,
-  )
-where
-
-import Foreign.Marshal

--- a/library/Rebase/Foreign/Marshal/Alloc.hs
+++ b/library/Rebase/Foreign/Marshal/Alloc.hs
@@ -1,6 +1,0 @@
-module Rebase.Foreign.Marshal.Alloc
-  ( module Foreign.Marshal.Alloc,
-  )
-where
-
-import Foreign.Marshal.Alloc

--- a/library/Rebase/Foreign/Marshal/Array.hs
+++ b/library/Rebase/Foreign/Marshal/Array.hs
@@ -1,6 +1,0 @@
-module Rebase.Foreign.Marshal.Array
-  ( module Foreign.Marshal.Array,
-  )
-where
-
-import Foreign.Marshal.Array

--- a/library/Rebase/Foreign/Marshal/Error.hs
+++ b/library/Rebase/Foreign/Marshal/Error.hs
@@ -1,6 +1,0 @@
-module Rebase.Foreign.Marshal.Error
-  ( module Foreign.Marshal.Error,
-  )
-where
-
-import Foreign.Marshal.Error

--- a/library/Rebase/Foreign/Marshal/Pool.hs
+++ b/library/Rebase/Foreign/Marshal/Pool.hs
@@ -1,6 +1,0 @@
-module Rebase.Foreign.Marshal.Pool
-  ( module Foreign.Marshal.Pool,
-  )
-where
-
-import Foreign.Marshal.Pool

--- a/library/Rebase/Foreign/Marshal/Safe.hs
+++ b/library/Rebase/Foreign/Marshal/Safe.hs
@@ -1,6 +1,0 @@
-module Rebase.Foreign.Marshal.Safe
-  ( module Foreign.Marshal.Safe,
-  )
-where
-
-import Foreign.Marshal.Safe

--- a/library/Rebase/Foreign/Marshal/Unsafe.hs
+++ b/library/Rebase/Foreign/Marshal/Unsafe.hs
@@ -1,6 +1,0 @@
-module Rebase.Foreign.Marshal.Unsafe
-  ( module Foreign.Marshal.Unsafe,
-  )
-where
-
-import Foreign.Marshal.Unsafe

--- a/library/Rebase/Foreign/Marshal/Utils.hs
+++ b/library/Rebase/Foreign/Marshal/Utils.hs
@@ -1,6 +1,0 @@
-module Rebase.Foreign.Marshal.Utils
-  ( module Foreign.Marshal.Utils,
-  )
-where
-
-import Foreign.Marshal.Utils

--- a/library/Rebase/Foreign/Ptr.hs
+++ b/library/Rebase/Foreign/Ptr.hs
@@ -1,6 +1,0 @@
-module Rebase.Foreign.Ptr
-  ( module Foreign.Ptr,
-  )
-where
-
-import Foreign.Ptr

--- a/library/Rebase/Foreign/StablePtr.hs
+++ b/library/Rebase/Foreign/StablePtr.hs
@@ -1,6 +1,0 @@
-module Rebase.Foreign.StablePtr
-  ( module Foreign.StablePtr,
-  )
-where
-
-import Foreign.StablePtr

--- a/library/Rebase/Foreign/Storable.hs
+++ b/library/Rebase/Foreign/Storable.hs
@@ -1,6 +1,0 @@
-module Rebase.Foreign.Storable
-  ( module Foreign.Storable,
-  )
-where
-
-import Foreign.Storable

--- a/library/Rebase/GHC/Arr.hs
+++ b/library/Rebase/GHC/Arr.hs
@@ -1,6 +1,0 @@
-module Rebase.GHC.Arr
-  ( module GHC.Arr,
-  )
-where
-
-import GHC.Arr

--- a/library/Rebase/GHC/Base.hs
+++ b/library/Rebase/GHC/Base.hs
@@ -1,6 +1,0 @@
-module Rebase.GHC.Base
-  ( module GHC.Base,
-  )
-where
-
-import GHC.Base

--- a/library/Rebase/GHC/Char.hs
+++ b/library/Rebase/GHC/Char.hs
@@ -1,6 +1,0 @@
-module Rebase.GHC.Char
-  ( module GHC.Char,
-  )
-where
-
-import GHC.Char

--- a/library/Rebase/GHC/Conc.hs
+++ b/library/Rebase/GHC/Conc.hs
@@ -1,6 +1,0 @@
-module Rebase.GHC.Conc
-  ( module GHC.Conc,
-  )
-where
-
-import GHC.Conc

--- a/library/Rebase/GHC/Conc/IO.hs
+++ b/library/Rebase/GHC/Conc/IO.hs
@@ -1,6 +1,0 @@
-module Rebase.GHC.Conc.IO
-  ( module GHC.Conc.IO,
-  )
-where
-
-import GHC.Conc.IO

--- a/library/Rebase/GHC/Conc/Signal.hs
+++ b/library/Rebase/GHC/Conc/Signal.hs
@@ -1,6 +1,0 @@
-module Rebase.GHC.Conc.Signal
-  ( module GHC.Conc.Signal,
-  )
-where
-
-import GHC.Conc.Signal

--- a/library/Rebase/GHC/Conc/Sync.hs
+++ b/library/Rebase/GHC/Conc/Sync.hs
@@ -1,6 +1,0 @@
-module Rebase.GHC.Conc.Sync
-  ( module GHC.Conc.Sync,
-  )
-where
-
-import GHC.Conc.Sync

--- a/library/Rebase/GHC/Enum.hs
+++ b/library/Rebase/GHC/Enum.hs
@@ -1,6 +1,0 @@
-module Rebase.GHC.Enum
-  ( module GHC.Enum,
-  )
-where
-
-import GHC.Enum

--- a/library/Rebase/GHC/Environment.hs
+++ b/library/Rebase/GHC/Environment.hs
@@ -1,6 +1,0 @@
-module Rebase.GHC.Environment
-  ( module GHC.Environment,
-  )
-where
-
-import GHC.Environment

--- a/library/Rebase/GHC/Err.hs
+++ b/library/Rebase/GHC/Err.hs
@@ -1,6 +1,0 @@
-module Rebase.GHC.Err
-  ( module GHC.Err,
-  )
-where
-
-import GHC.Err

--- a/library/Rebase/GHC/Exception.hs
+++ b/library/Rebase/GHC/Exception.hs
@@ -1,6 +1,0 @@
-module Rebase.GHC.Exception
-  ( module GHC.Exception,
-  )
-where
-
-import GHC.Exception

--- a/library/Rebase/GHC/Exts.hs
+++ b/library/Rebase/GHC/Exts.hs
@@ -1,6 +1,0 @@
-module Rebase.GHC.Exts
-  ( module GHC.Exts,
-  )
-where
-
-import GHC.Exts

--- a/library/Rebase/GHC/Fingerprint.hs
+++ b/library/Rebase/GHC/Fingerprint.hs
@@ -1,6 +1,0 @@
-module Rebase.GHC.Fingerprint
-  ( module GHC.Fingerprint,
-  )
-where
-
-import GHC.Fingerprint

--- a/library/Rebase/GHC/Fingerprint/Type.hs
+++ b/library/Rebase/GHC/Fingerprint/Type.hs
@@ -1,6 +1,0 @@
-module Rebase.GHC.Fingerprint.Type
-  ( module GHC.Fingerprint.Type,
-  )
-where
-
-import GHC.Fingerprint.Type

--- a/library/Rebase/GHC/Float.hs
+++ b/library/Rebase/GHC/Float.hs
@@ -1,6 +1,0 @@
-module Rebase.GHC.Float
-  ( module GHC.Float,
-  )
-where
-
-import GHC.Float

--- a/library/Rebase/GHC/Float/ConversionUtils.hs
+++ b/library/Rebase/GHC/Float/ConversionUtils.hs
@@ -1,6 +1,0 @@
-module Rebase.GHC.Float.ConversionUtils
-  ( module GHC.Float.ConversionUtils,
-  )
-where
-
-import GHC.Float.ConversionUtils

--- a/library/Rebase/GHC/Float/RealFracMethods.hs
+++ b/library/Rebase/GHC/Float/RealFracMethods.hs
@@ -1,6 +1,0 @@
-module Rebase.GHC.Float.RealFracMethods
-  ( module GHC.Float.RealFracMethods,
-  )
-where
-
-import GHC.Float.RealFracMethods

--- a/library/Rebase/GHC/Foreign.hs
+++ b/library/Rebase/GHC/Foreign.hs
@@ -1,6 +1,0 @@
-module Rebase.GHC.Foreign
-  ( module GHC.Foreign,
-  )
-where
-
-import GHC.Foreign

--- a/library/Rebase/GHC/ForeignPtr.hs
+++ b/library/Rebase/GHC/ForeignPtr.hs
@@ -1,6 +1,0 @@
-module Rebase.GHC.ForeignPtr
-  ( module GHC.ForeignPtr,
-  )
-where
-
-import GHC.ForeignPtr

--- a/library/Rebase/GHC/Generics.hs
+++ b/library/Rebase/GHC/Generics.hs
@@ -1,6 +1,0 @@
-module Rebase.GHC.Generics
-  ( module GHC.Generics,
-  )
-where
-
-import GHC.Generics

--- a/library/Rebase/GHC/IO.hs
+++ b/library/Rebase/GHC/IO.hs
@@ -1,6 +1,0 @@
-module Rebase.GHC.IO
-  ( module GHC.IO,
-  )
-where
-
-import GHC.IO

--- a/library/Rebase/GHC/IO/Buffer.hs
+++ b/library/Rebase/GHC/IO/Buffer.hs
@@ -1,6 +1,0 @@
-module Rebase.GHC.IO.Buffer
-  ( module GHC.IO.Buffer,
-  )
-where
-
-import GHC.IO.Buffer

--- a/library/Rebase/GHC/IO/BufferedIO.hs
+++ b/library/Rebase/GHC/IO/BufferedIO.hs
@@ -1,6 +1,0 @@
-module Rebase.GHC.IO.BufferedIO
-  ( module GHC.IO.BufferedIO,
-  )
-where
-
-import GHC.IO.BufferedIO

--- a/library/Rebase/GHC/IO/Device.hs
+++ b/library/Rebase/GHC/IO/Device.hs
@@ -1,6 +1,0 @@
-module Rebase.GHC.IO.Device
-  ( module GHC.IO.Device,
-  )
-where
-
-import GHC.IO.Device

--- a/library/Rebase/GHC/IO/Encoding.hs
+++ b/library/Rebase/GHC/IO/Encoding.hs
@@ -1,6 +1,0 @@
-module Rebase.GHC.IO.Encoding
-  ( module GHC.IO.Encoding,
-  )
-where
-
-import GHC.IO.Encoding

--- a/library/Rebase/GHC/IO/Encoding/Failure.hs
+++ b/library/Rebase/GHC/IO/Encoding/Failure.hs
@@ -1,6 +1,0 @@
-module Rebase.GHC.IO.Encoding.Failure
-  ( module GHC.IO.Encoding.Failure,
-  )
-where
-
-import GHC.IO.Encoding.Failure

--- a/library/Rebase/GHC/IO/Encoding/Iconv.hs
+++ b/library/Rebase/GHC/IO/Encoding/Iconv.hs
@@ -1,6 +1,0 @@
-module Rebase.GHC.IO.Encoding.Iconv
-  ( module GHC.IO.Encoding.Iconv,
-  )
-where
-
-import GHC.IO.Encoding.Iconv

--- a/library/Rebase/GHC/IO/Encoding/Latin1.hs
+++ b/library/Rebase/GHC/IO/Encoding/Latin1.hs
@@ -1,6 +1,0 @@
-module Rebase.GHC.IO.Encoding.Latin1
-  ( module GHC.IO.Encoding.Latin1,
-  )
-where
-
-import GHC.IO.Encoding.Latin1

--- a/library/Rebase/GHC/IO/Encoding/Types.hs
+++ b/library/Rebase/GHC/IO/Encoding/Types.hs
@@ -1,6 +1,0 @@
-module Rebase.GHC.IO.Encoding.Types
-  ( module GHC.IO.Encoding.Types,
-  )
-where
-
-import GHC.IO.Encoding.Types

--- a/library/Rebase/GHC/IO/Encoding/UTF16.hs
+++ b/library/Rebase/GHC/IO/Encoding/UTF16.hs
@@ -1,6 +1,0 @@
-module Rebase.GHC.IO.Encoding.UTF16
-  ( module GHC.IO.Encoding.UTF16,
-  )
-where
-
-import GHC.IO.Encoding.UTF16

--- a/library/Rebase/GHC/IO/Encoding/UTF32.hs
+++ b/library/Rebase/GHC/IO/Encoding/UTF32.hs
@@ -1,6 +1,0 @@
-module Rebase.GHC.IO.Encoding.UTF32
-  ( module GHC.IO.Encoding.UTF32,
-  )
-where
-
-import GHC.IO.Encoding.UTF32

--- a/library/Rebase/GHC/IO/Encoding/UTF8.hs
+++ b/library/Rebase/GHC/IO/Encoding/UTF8.hs
@@ -1,6 +1,0 @@
-module Rebase.GHC.IO.Encoding.UTF8
-  ( module GHC.IO.Encoding.UTF8,
-  )
-where
-
-import GHC.IO.Encoding.UTF8

--- a/library/Rebase/GHC/IO/Exception.hs
+++ b/library/Rebase/GHC/IO/Exception.hs
@@ -1,6 +1,0 @@
-module Rebase.GHC.IO.Exception
-  ( module GHC.IO.Exception,
-  )
-where
-
-import GHC.IO.Exception

--- a/library/Rebase/GHC/IO/FD.hs
+++ b/library/Rebase/GHC/IO/FD.hs
@@ -1,6 +1,0 @@
-module Rebase.GHC.IO.FD
-  ( module GHC.IO.FD,
-  )
-where
-
-import GHC.IO.FD

--- a/library/Rebase/GHC/IO/Handle.hs
+++ b/library/Rebase/GHC/IO/Handle.hs
@@ -1,6 +1,0 @@
-module Rebase.GHC.IO.Handle
-  ( module GHC.IO.Handle,
-  )
-where
-
-import GHC.IO.Handle

--- a/library/Rebase/GHC/IO/Handle/FD.hs
+++ b/library/Rebase/GHC/IO/Handle/FD.hs
@@ -1,6 +1,0 @@
-module Rebase.GHC.IO.Handle.FD
-  ( module GHC.IO.Handle.FD,
-  )
-where
-
-import GHC.IO.Handle.FD

--- a/library/Rebase/GHC/IO/Handle/Internals.hs
+++ b/library/Rebase/GHC/IO/Handle/Internals.hs
@@ -1,6 +1,0 @@
-module Rebase.GHC.IO.Handle.Internals
-  ( module GHC.IO.Handle.Internals,
-  )
-where
-
-import GHC.IO.Handle.Internals

--- a/library/Rebase/GHC/IO/Handle/Text.hs
+++ b/library/Rebase/GHC/IO/Handle/Text.hs
@@ -1,6 +1,0 @@
-module Rebase.GHC.IO.Handle.Text
-  ( module GHC.IO.Handle.Text,
-  )
-where
-
-import GHC.IO.Handle.Text

--- a/library/Rebase/GHC/IO/Handle/Types.hs
+++ b/library/Rebase/GHC/IO/Handle/Types.hs
@@ -1,6 +1,0 @@
-module Rebase.GHC.IO.Handle.Types
-  ( module GHC.IO.Handle.Types,
-  )
-where
-
-import GHC.IO.Handle.Types

--- a/library/Rebase/GHC/IO/IOMode.hs
+++ b/library/Rebase/GHC/IO/IOMode.hs
@@ -1,6 +1,0 @@
-module Rebase.GHC.IO.IOMode
-  ( module GHC.IO.IOMode,
-  )
-where
-
-import GHC.IO.IOMode

--- a/library/Rebase/GHC/IOArray.hs
+++ b/library/Rebase/GHC/IOArray.hs
@@ -1,6 +1,0 @@
-module Rebase.GHC.IOArray
-  ( module GHC.IOArray,
-  )
-where
-
-import GHC.IOArray

--- a/library/Rebase/GHC/IORef.hs
+++ b/library/Rebase/GHC/IORef.hs
@@ -1,6 +1,0 @@
-module Rebase.GHC.IORef
-  ( module GHC.IORef,
-  )
-where
-
-import GHC.IORef

--- a/library/Rebase/GHC/Int.hs
+++ b/library/Rebase/GHC/Int.hs
@@ -1,6 +1,0 @@
-module Rebase.GHC.Int
-  ( module GHC.Int,
-  )
-where
-
-import GHC.Int

--- a/library/Rebase/GHC/List.hs
+++ b/library/Rebase/GHC/List.hs
@@ -1,6 +1,0 @@
-module Rebase.GHC.List
-  ( module GHC.List,
-  )
-where
-
-import GHC.List

--- a/library/Rebase/GHC/MVar.hs
+++ b/library/Rebase/GHC/MVar.hs
@@ -1,6 +1,0 @@
-module Rebase.GHC.MVar
-  ( module GHC.MVar,
-  )
-where
-
-import GHC.MVar

--- a/library/Rebase/GHC/Num.hs
+++ b/library/Rebase/GHC/Num.hs
@@ -1,6 +1,0 @@
-module Rebase.GHC.Num
-  ( module GHC.Num,
-  )
-where
-
-import GHC.Num

--- a/library/Rebase/GHC/OverloadedLabels.hs
+++ b/library/Rebase/GHC/OverloadedLabels.hs
@@ -1,6 +1,0 @@
-module Rebase.GHC.OverloadedLabels
-  ( module GHC.OverloadedLabels,
-  )
-where
-
-import GHC.OverloadedLabels

--- a/library/Rebase/GHC/Profiling.hs
+++ b/library/Rebase/GHC/Profiling.hs
@@ -1,6 +1,0 @@
-module Rebase.GHC.Profiling
-  ( module GHC.Profiling,
-  )
-where
-
-import GHC.Profiling

--- a/library/Rebase/GHC/Ptr.hs
+++ b/library/Rebase/GHC/Ptr.hs
@@ -1,6 +1,0 @@
-module Rebase.GHC.Ptr
-  ( module GHC.Ptr,
-  )
-where
-
-import GHC.Ptr

--- a/library/Rebase/GHC/Read.hs
+++ b/library/Rebase/GHC/Read.hs
@@ -1,6 +1,0 @@
-module Rebase.GHC.Read
-  ( module GHC.Read,
-  )
-where
-
-import GHC.Read

--- a/library/Rebase/GHC/Real.hs
+++ b/library/Rebase/GHC/Real.hs
@@ -1,6 +1,0 @@
-module Rebase.GHC.Real
-  ( module GHC.Real,
-  )
-where
-
-import GHC.Real

--- a/library/Rebase/GHC/Records.hs
+++ b/library/Rebase/GHC/Records.hs
@@ -1,6 +1,0 @@
-module Rebase.GHC.Records
-  ( module GHC.Records,
-  )
-where
-
-import GHC.Records

--- a/library/Rebase/GHC/ST.hs
+++ b/library/Rebase/GHC/ST.hs
@@ -1,6 +1,0 @@
-module Rebase.GHC.ST
-  ( module GHC.ST,
-  )
-where
-
-import GHC.ST

--- a/library/Rebase/GHC/STRef.hs
+++ b/library/Rebase/GHC/STRef.hs
@@ -1,6 +1,0 @@
-module Rebase.GHC.STRef
-  ( module GHC.STRef,
-  )
-where
-
-import GHC.STRef

--- a/library/Rebase/GHC/Show.hs
+++ b/library/Rebase/GHC/Show.hs
@@ -1,6 +1,0 @@
-module Rebase.GHC.Show
-  ( module GHC.Show,
-  )
-where
-
-import GHC.Show

--- a/library/Rebase/GHC/Stable.hs
+++ b/library/Rebase/GHC/Stable.hs
@@ -1,6 +1,0 @@
-module Rebase.GHC.Stable
-  ( module GHC.Stable,
-  )
-where
-
-import GHC.Stable

--- a/library/Rebase/GHC/Stack.hs
+++ b/library/Rebase/GHC/Stack.hs
@@ -1,6 +1,0 @@
-module Rebase.GHC.Stack
-  ( module GHC.Stack,
-  )
-where
-
-import GHC.Stack

--- a/library/Rebase/GHC/Stats.hs
+++ b/library/Rebase/GHC/Stats.hs
@@ -1,6 +1,0 @@
-module Rebase.GHC.Stats
-  ( module GHC.Stats,
-  )
-where
-
-import GHC.Stats

--- a/library/Rebase/GHC/Storable.hs
+++ b/library/Rebase/GHC/Storable.hs
@@ -1,6 +1,0 @@
-module Rebase.GHC.Storable
-  ( module GHC.Storable,
-  )
-where
-
-import GHC.Storable

--- a/library/Rebase/GHC/TopHandler.hs
+++ b/library/Rebase/GHC/TopHandler.hs
@@ -1,6 +1,0 @@
-module Rebase.GHC.TopHandler
-  ( module GHC.TopHandler,
-  )
-where
-
-import GHC.TopHandler

--- a/library/Rebase/GHC/TypeLits.hs
+++ b/library/Rebase/GHC/TypeLits.hs
@@ -1,6 +1,0 @@
-module Rebase.GHC.TypeLits
-  ( module GHC.TypeLits,
-  )
-where
-
-import GHC.TypeLits

--- a/library/Rebase/GHC/TypeNats.hs
+++ b/library/Rebase/GHC/TypeNats.hs
@@ -1,6 +1,0 @@
-module Rebase.GHC.TypeNats
-  ( module GHC.TypeNats,
-  )
-where
-
-import GHC.TypeNats

--- a/library/Rebase/GHC/Unicode.hs
+++ b/library/Rebase/GHC/Unicode.hs
@@ -1,6 +1,0 @@
-module Rebase.GHC.Unicode
-  ( module GHC.Unicode,
-  )
-where
-
-import GHC.Unicode

--- a/library/Rebase/GHC/Weak.hs
+++ b/library/Rebase/GHC/Weak.hs
@@ -1,6 +1,0 @@
-module Rebase.GHC.Weak
-  ( module GHC.Weak,
-  )
-where
-
-import GHC.Weak

--- a/library/Rebase/GHC/Word.hs
+++ b/library/Rebase/GHC/Word.hs
@@ -1,6 +1,0 @@
-module Rebase.GHC.Word
-  ( module GHC.Word,
-  )
-where
-
-import GHC.Word

--- a/library/Rebase/Numeric.hs
+++ b/library/Rebase/Numeric.hs
@@ -1,6 +1,0 @@
-module Rebase.Numeric
-  ( module Numeric,
-  )
-where
-
-import Numeric

--- a/library/Rebase/Numeric/Natural.hs
+++ b/library/Rebase/Numeric/Natural.hs
@@ -1,6 +1,0 @@
-module Rebase.Numeric.Natural
-  ( module Numeric.Natural,
-  )
-where
-
-import Numeric.Natural

--- a/library/Rebase/Prelude.hs
+++ b/library/Rebase/Prelude.hs
@@ -11,147 +11,147 @@ module Rebase.Prelude
   )
 where
 
-import Rebase.Control.Applicative as Exports
-import Rebase.Control.Arrow as Exports hiding (first, second)
-import Rebase.Control.Category as Exports
-import Rebase.Control.Concurrent as Exports
-import Rebase.Control.Exception as Exports
-import Rebase.Control.Monad as Exports hiding (fail, forM, forM_, mapM, mapM_, msum, sequence, sequence_)
-import Rebase.Control.Monad.Fail as Exports
-import Rebase.Control.Monad.Fix as Exports hiding (fix)
-import Rebase.Control.Monad.IO.Class as Exports
-import Rebase.Control.Monad.ST as Exports
+import Control.Applicative as Exports
+import Control.Arrow as Exports hiding (first, second)
+import Control.Category as Exports
+import Control.Concurrent as Exports
+import Control.Exception as Exports
+import Control.Monad as Exports hiding (fail, forM, forM_, mapM, mapM_, msum, sequence, sequence_)
+import Control.Monad.Fail as Exports
+import Control.Monad.Fix as Exports hiding (fix)
+import Control.Monad.IO.Class as Exports
+import Control.Monad.ST as Exports
 import Rebase.Data.Bifunctor as Exports
-import Rebase.Data.Bits as Exports
-import Rebase.Data.Bool as Exports
-import Rebase.Data.Char as Exports
-import Rebase.Data.Coerce as Exports
-import Rebase.Data.Complex as Exports
-import Rebase.Data.Data as Exports
-import Rebase.Data.Dynamic as Exports
-import Rebase.Data.Either as Exports
-import Rebase.Data.Fixed as Exports
-import Rebase.Data.Foldable as Exports hiding (toList)
-import Rebase.Data.Function as Exports hiding (id, (.))
+import Data.Bits as Exports
+import Data.Bool as Exports
+import Data.Char as Exports
+import Data.Coerce as Exports
+import Data.Complex as Exports
+import Data.Data as Exports
+import Data.Dynamic as Exports
+import Data.Either as Exports
+import Data.Fixed as Exports
+import Data.Foldable as Exports hiding (toList)
+import Data.Function as Exports hiding (id, (.))
 import Prelude as Exports hiding (all, and, any, concat, concatMap, elem, fail, foldl, foldl1, foldr, foldr1, id, mapM, mapM_, maximum, minimum, notElem, or, product, sequence, sequence_, sum, (.))
 #if MIN_VERSION_base(4,19,0)
-import Rebase.Data.Functor as Exports hiding (unzip)
+import Data.Functor as Exports hiding (unzip)
 #else
-import Rebase.Data.Functor as Exports
+import Data.Functor as Exports
 #endif
-import Rebase.Control.Comonad as Exports
-import Rebase.Control.Concurrent.STM as Exports hiding (orElse)
-import Rebase.Control.DeepSeq as Exports
-import Rebase.Control.Monad.Cont.Class as Exports
-import Rebase.Control.Monad.Error.Class as Exports
-import Rebase.Control.Monad.Reader.Class as Exports
-import Rebase.Control.Monad.State.Class as Exports
-import Rebase.Control.Monad.Trans.Class as Exports
-import Rebase.Control.Monad.Trans.Cont as Exports hiding (callCC, shift)
-import Rebase.Control.Monad.Trans.Except as Exports (Except, ExceptT (ExceptT), except, mapExcept, mapExceptT, runExcept, runExceptT, withExcept, withExceptT)
-import Rebase.Control.Monad.Trans.Maybe as Exports (MaybeT (MaybeT), exceptToMaybeT, mapMaybeT, maybeToExceptT)
-import Rebase.Control.Monad.Trans.Reader as Exports (Reader, ReaderT (ReaderT), mapReader, mapReaderT, runReader, runReaderT, withReader, withReaderT)
-import Rebase.Control.Monad.Trans.State.Strict as Exports (State, StateT (StateT), evalState, evalStateT, execState, execStateT, mapState, mapStateT, runState, runStateT, withState, withStateT)
-import Rebase.Control.Monad.Trans.Writer.Strict as Exports (Writer, WriterT (WriterT), execWriter, execWriterT, mapWriter, mapWriterT, runWriter)
-import Rebase.Control.Monad.Writer.Class as Exports
-import Rebase.Control.Selective as Exports hiding (swapEither)
-import Rebase.Data.Bifunctor.Apply as Exports
-import Rebase.Data.ByteString as Exports (ByteString)
-import Rebase.Data.ByteString.Short as Exports (ShortByteString)
-import Rebase.Data.DList as Exports (DList)
-import Rebase.Data.Either.Combinators as Exports hiding (fromLeft, fromRight, isLeft, isRight, mapLeft, mapRight)
-import Rebase.Data.Functor.Alt as Exports hiding (many, optional, some, ($>))
-import Rebase.Data.Functor.Bind as Exports hiding (join, ($>))
-import Rebase.Data.Functor.Classes as Exports
-import Rebase.Data.Functor.Compose as Exports
-import Rebase.Data.Functor.Contravariant as Exports
-import Rebase.Data.Functor.Contravariant.Divisible as Exports
-import Rebase.Data.Functor.Extend as Exports
-import Rebase.Data.Functor.Identity as Exports
-import Rebase.Data.Functor.Invariant as Exports
-import Rebase.Data.Functor.Plus as Exports hiding (many, optional, some, ($>))
-import Rebase.Data.Group as Exports
-import Rebase.Data.Groupoid as Exports
-import Rebase.Data.HashMap.Strict as Exports (HashMap)
-import Rebase.Data.HashSet as Exports (HashSet)
-import Rebase.Data.Hashable as Exports
-import Rebase.Data.IORef as Exports
-import Rebase.Data.Int as Exports
-import Rebase.Data.IntMap.Strict as Exports (IntMap)
-import Rebase.Data.IntSet as Exports (IntSet)
-import Rebase.Data.Ix as Exports
-import Rebase.Data.List as Exports hiding (all, and, any, concat, concatMap, elem, find, foldl, foldl', foldl1, foldr, foldr1, mapAccumL, mapAccumR, maximum, maximumBy, minimum, minimumBy, notElem, or, product, sum)
-import Rebase.Data.List.NonEmpty as Exports (NonEmpty (..))
-import Rebase.Data.Map.Strict as Exports (Map)
-import Rebase.Data.Maybe as Exports
-import Rebase.Data.Monoid as Exports hiding (Alt, First (..), Last (..), (<>))
-import Rebase.Data.Ord as Exports
-import Rebase.Data.Profunctor as Exports hiding (WrappedArrow (..))
-import Rebase.Data.Profunctor.Adjunction as Exports
-import Rebase.Data.Profunctor.Cayley as Exports
-import Rebase.Data.Profunctor.Choice as Exports
-import Rebase.Data.Profunctor.Closed as Exports
-import Rebase.Data.Profunctor.Composition as Exports
-import Rebase.Data.Profunctor.Mapping as Exports
-import Rebase.Data.Profunctor.Monad as Exports
-import Rebase.Data.Profunctor.Ran as Exports
-import Rebase.Data.Profunctor.Rep as Exports
-import Rebase.Data.Profunctor.Sieve as Exports
-import Rebase.Data.Profunctor.Strong as Exports
-import Rebase.Data.Profunctor.Traversing as Exports
-import Rebase.Data.Profunctor.Unsafe as Exports
-import Rebase.Data.Profunctor.Yoneda as Exports
-import Rebase.Data.Proxy as Exports
-import Rebase.Data.Ratio as Exports
-import Rebase.Data.STRef as Exports
-import Rebase.Data.Scientific as Exports (Scientific)
-import Rebase.Data.Semigroup as Exports
-import Rebase.Data.Semigroup.Bifoldable as Exports
-import Rebase.Data.Semigroup.Bitraversable as Exports
-import Rebase.Data.Semigroup.Foldable as Exports
-import Rebase.Data.Semigroup.Traversable as Exports
-import Rebase.Data.Semigroupoid as Exports
-import Rebase.Data.Sequence as Exports (Seq)
-import Rebase.Data.Set as Exports (Set)
-import Rebase.Data.String as Exports
+import Control.Comonad as Exports
+import Control.Concurrent.STM as Exports hiding (orElse)
+import Control.DeepSeq as Exports
+import Control.Monad.Cont.Class as Exports
+import Control.Monad.Error.Class as Exports
+import Control.Monad.Reader.Class as Exports
+import Control.Monad.State.Class as Exports
+import Control.Monad.Trans.Class as Exports
+import Control.Monad.Trans.Cont as Exports hiding (callCC, shift)
+import Control.Monad.Trans.Except as Exports (Except, ExceptT (ExceptT), except, mapExcept, mapExceptT, runExcept, runExceptT, withExcept, withExceptT)
+import Control.Monad.Trans.Maybe as Exports (MaybeT (MaybeT), exceptToMaybeT, mapMaybeT, maybeToExceptT)
+import Control.Monad.Trans.Reader as Exports (Reader, ReaderT (ReaderT), mapReader, mapReaderT, runReader, runReaderT, withReader, withReaderT)
+import Control.Monad.Trans.State.Strict as Exports (State, StateT (StateT), evalState, evalStateT, execState, execStateT, mapState, mapStateT, runState, runStateT, withState, withStateT)
+import Control.Monad.Trans.Writer.Strict as Exports (Writer, WriterT (WriterT), execWriter, execWriterT, mapWriter, mapWriterT, runWriter)
+import Control.Monad.Writer.Class as Exports
+import Control.Selective as Exports hiding (swapEither)
+import Data.Bifunctor.Apply as Exports
+import Data.ByteString as Exports (ByteString)
+import Data.ByteString.Short as Exports (ShortByteString)
+import Data.DList as Exports (DList)
+import Data.Either.Combinators as Exports hiding (fromLeft, fromRight, isLeft, isRight, mapLeft, mapRight)
+import Data.Functor.Alt as Exports hiding (many, optional, some, ($>))
+import Data.Functor.Bind as Exports hiding (join, ($>))
+import Data.Functor.Classes as Exports
+import Data.Functor.Compose as Exports
+import Data.Functor.Contravariant as Exports
+import Data.Functor.Contravariant.Divisible as Exports
+import Data.Functor.Extend as Exports
+import Data.Functor.Identity as Exports
+import Data.Functor.Invariant as Exports
+import Data.Functor.Plus as Exports hiding (many, optional, some, ($>))
+import Data.Group as Exports
+import Data.Groupoid as Exports
+import Data.HashMap.Strict as Exports (HashMap)
+import Data.HashSet as Exports (HashSet)
+import Data.Hashable as Exports
+import Data.IORef as Exports
+import Data.Int as Exports
+import Data.IntMap.Strict as Exports (IntMap)
+import Data.IntSet as Exports (IntSet)
+import Data.Ix as Exports
+import Data.List as Exports hiding (all, and, any, concat, concatMap, elem, find, foldl, foldl', foldl1, foldr, foldr1, mapAccumL, mapAccumR, maximum, maximumBy, minimum, minimumBy, notElem, or, product, sum)
+import Data.List.NonEmpty as Exports (NonEmpty (..))
+import Data.Map.Strict as Exports (Map)
+import Data.Maybe as Exports
+import Data.Monoid as Exports hiding (Alt, First (..), Last (..), (<>))
+import Data.Ord as Exports
+import Data.Profunctor as Exports hiding (WrappedArrow (..))
+import Data.Profunctor.Adjunction as Exports
+import Data.Profunctor.Cayley as Exports
+import Data.Profunctor.Choice as Exports
+import Data.Profunctor.Closed as Exports
+import Data.Profunctor.Composition as Exports
+import Data.Profunctor.Mapping as Exports
+import Data.Profunctor.Monad as Exports
+import Data.Profunctor.Ran as Exports
+import Data.Profunctor.Rep as Exports
+import Data.Profunctor.Sieve as Exports
+import Data.Profunctor.Strong as Exports
+import Data.Profunctor.Traversing as Exports
+import Data.Profunctor.Unsafe as Exports
+import Data.Profunctor.Yoneda as Exports
+import Data.Proxy as Exports
+import Data.Ratio as Exports
+import Data.STRef as Exports
+import Data.Scientific as Exports (Scientific)
+import Data.Semigroup as Exports
+import Data.Semigroup.Bifoldable as Exports
+import Data.Semigroup.Bitraversable as Exports
+import Data.Semigroup.Foldable as Exports
+import Data.Semigroup.Traversable as Exports
+import Data.Semigroupoid as Exports
+import Data.Sequence as Exports (Seq)
+import Data.Set as Exports (Set)
+import Data.String as Exports
 import Rebase.Data.Text as Exports (Text)
-import Rebase.Data.Time as Exports
-import Rebase.Data.Time.Clock.POSIX as Exports
-import Rebase.Data.Time.Clock.System as Exports
-import Rebase.Data.Time.Compat as Exports ()
-import Rebase.Data.Time.Format.ISO8601 as Exports (ISO8601 (..), iso8601ParseM, iso8601Show)
-import Rebase.Data.Traversable as Exports
-import Rebase.Data.Tuple as Exports
-import Rebase.Data.UUID as Exports (UUID)
-import Rebase.Data.Unique as Exports
-import Rebase.Data.Vector as Exports (Vector)
-import Rebase.Data.Vector.Instances as Exports ()
-import Rebase.Data.Version as Exports
-import Rebase.Data.Void as Exports
-import Rebase.Data.Void.Unsafe as Exports
-import Rebase.Data.Word as Exports
-import Rebase.Debug.Trace as Exports
-import Rebase.Foreign.ForeignPtr as Exports
-import Rebase.Foreign.Ptr as Exports
-import Rebase.Foreign.StablePtr as Exports
-import Rebase.Foreign.Storable as Exports
-import Rebase.GHC.Conc as Exports hiding (orElse, threadWaitRead, threadWaitReadSTM, threadWaitWrite, threadWaitWriteSTM, withMVar)
-import Rebase.GHC.Exts as Exports (IsList (..), groupWith, inline, lazy, sortWith)
-import Rebase.GHC.Generics as Exports (Generic)
-import Rebase.GHC.IO.Exception as Exports
-import Rebase.GHC.OverloadedLabels as Exports
-import Rebase.GHC.Records as Exports
-import Rebase.Numeric as Exports
-import Rebase.Numeric.Natural as Exports
-import Rebase.System.Environment as Exports
-import Rebase.System.Exit as Exports
-import Rebase.System.IO as Exports (Handle, hClose)
-import Rebase.System.IO.Error as Exports
-import Rebase.System.IO.Unsafe as Exports
-import Rebase.System.Mem as Exports
-import Rebase.System.Mem.StableName as Exports
-import Rebase.System.Timeout as Exports
-import Rebase.Text.ParserCombinators.ReadPrec as Exports (ReadPrec, readP_to_Prec, readPrec_to_P, readPrec_to_S, readS_to_Prec)
-import Rebase.Text.Printf as Exports (hPrintf, printf)
-import Rebase.Text.Read as Exports (Read (..), readEither, readMaybe)
-import Rebase.Unsafe.Coerce as Exports
+import Data.Time as Exports
+import Data.Time.Clock.POSIX as Exports
+import Data.Time.Clock.System as Exports
+import Data.Time.Compat as Exports ()
+import Data.Time.Format.ISO8601 as Exports (ISO8601 (..), iso8601ParseM, iso8601Show)
+import Data.Traversable as Exports
+import Data.Tuple as Exports
+import Data.UUID.Types as Exports (UUID)
+import Data.Unique as Exports
+import Data.Vector as Exports (Vector)
+import Data.Vector.Instances as Exports ()
+import Data.Version as Exports
+import Data.Void as Exports
+import Data.Void.Unsafe as Exports
+import Data.Word as Exports
+import Debug.Trace as Exports
+import Foreign.ForeignPtr as Exports
+import Foreign.Ptr as Exports
+import Foreign.StablePtr as Exports
+import Foreign.Storable as Exports
+import GHC.Conc as Exports hiding (orElse, threadWaitRead, threadWaitReadSTM, threadWaitWrite, threadWaitWriteSTM, withMVar)
+import GHC.Exts as Exports (IsList (..), groupWith, inline, lazy, sortWith)
+import GHC.Generics as Exports (Generic)
+import GHC.IO.Exception as Exports
+import GHC.OverloadedLabels as Exports
+import GHC.Records as Exports
+import Numeric as Exports
+import Numeric.Natural as Exports
+import System.Environment as Exports
+import System.Exit as Exports
+import System.IO as Exports (Handle, hClose)
+import System.IO.Error as Exports
+import System.IO.Unsafe as Exports
+import System.Mem as Exports
+import System.Mem.StableName as Exports
+import System.Timeout as Exports
+import Text.ParserCombinators.ReadPrec as Exports (ReadPrec, readP_to_Prec, readPrec_to_P, readPrec_to_S, readS_to_Prec)
+import Text.Printf as Exports (hPrintf, printf)
+import Text.Read as Exports (Read (..), readEither, readMaybe)
+import Unsafe.Coerce as Exports

--- a/library/Rebase/System/CPUTime.hs
+++ b/library/Rebase/System/CPUTime.hs
@@ -1,6 +1,0 @@
-module Rebase.System.CPUTime
-  ( module System.CPUTime,
-  )
-where
-
-import System.CPUTime

--- a/library/Rebase/System/Console/GetOpt.hs
+++ b/library/Rebase/System/Console/GetOpt.hs
@@ -1,6 +1,0 @@
-module Rebase.System.Console.GetOpt
-  ( module System.Console.GetOpt,
-  )
-where
-
-import System.Console.GetOpt

--- a/library/Rebase/System/Environment.hs
+++ b/library/Rebase/System/Environment.hs
@@ -1,6 +1,0 @@
-module Rebase.System.Environment
-  ( module System.Environment,
-  )
-where
-
-import System.Environment

--- a/library/Rebase/System/Exit.hs
+++ b/library/Rebase/System/Exit.hs
@@ -1,6 +1,0 @@
-module Rebase.System.Exit
-  ( module System.Exit,
-  )
-where
-
-import System.Exit

--- a/library/Rebase/System/IO.hs
+++ b/library/Rebase/System/IO.hs
@@ -1,6 +1,0 @@
-module Rebase.System.IO
-  ( module System.IO,
-  )
-where
-
-import System.IO

--- a/library/Rebase/System/IO/Error.hs
+++ b/library/Rebase/System/IO/Error.hs
@@ -1,6 +1,0 @@
-module Rebase.System.IO.Error
-  ( module System.IO.Error,
-  )
-where
-
-import System.IO.Error

--- a/library/Rebase/System/IO/Unsafe.hs
+++ b/library/Rebase/System/IO/Unsafe.hs
@@ -1,6 +1,0 @@
-module Rebase.System.IO.Unsafe
-  ( module System.IO.Unsafe,
-  )
-where
-
-import System.IO.Unsafe

--- a/library/Rebase/System/Info.hs
+++ b/library/Rebase/System/Info.hs
@@ -1,6 +1,0 @@
-module Rebase.System.Info
-  ( module System.Info,
-  )
-where
-
-import System.Info

--- a/library/Rebase/System/Mem.hs
+++ b/library/Rebase/System/Mem.hs
@@ -1,6 +1,0 @@
-module Rebase.System.Mem
-  ( module System.Mem,
-  )
-where
-
-import System.Mem

--- a/library/Rebase/System/Mem/StableName.hs
+++ b/library/Rebase/System/Mem/StableName.hs
@@ -1,6 +1,0 @@
-module Rebase.System.Mem.StableName
-  ( module System.Mem.StableName,
-  )
-where
-
-import System.Mem.StableName

--- a/library/Rebase/System/Mem/Weak.hs
+++ b/library/Rebase/System/Mem/Weak.hs
@@ -1,6 +1,0 @@
-module Rebase.System.Mem.Weak
-  ( module System.Mem.Weak,
-  )
-where
-
-import System.Mem.Weak

--- a/library/Rebase/System/Posix/Internals.hs
+++ b/library/Rebase/System/Posix/Internals.hs
@@ -1,6 +1,0 @@
-module Rebase.System.Posix.Internals
-  ( module System.Posix.Internals,
-  )
-where
-
-import System.Posix.Internals

--- a/library/Rebase/System/Posix/Types.hs
+++ b/library/Rebase/System/Posix/Types.hs
@@ -1,6 +1,0 @@
-module Rebase.System.Posix.Types
-  ( module System.Posix.Types,
-  )
-where
-
-import System.Posix.Types

--- a/library/Rebase/System/Timeout.hs
+++ b/library/Rebase/System/Timeout.hs
@@ -1,6 +1,0 @@
-module Rebase.System.Timeout
-  ( module System.Timeout,
-  )
-where
-
-import System.Timeout

--- a/library/Rebase/Text/ParserCombinators/ReadP.hs
+++ b/library/Rebase/Text/ParserCombinators/ReadP.hs
@@ -1,6 +1,0 @@
-module Rebase.Text.ParserCombinators.ReadP
-  ( module Text.ParserCombinators.ReadP,
-  )
-where
-
-import Text.ParserCombinators.ReadP

--- a/library/Rebase/Text/ParserCombinators/ReadPrec.hs
+++ b/library/Rebase/Text/ParserCombinators/ReadPrec.hs
@@ -1,6 +1,0 @@
-module Rebase.Text.ParserCombinators.ReadPrec
-  ( module Text.ParserCombinators.ReadPrec,
-  )
-where
-
-import Text.ParserCombinators.ReadPrec

--- a/library/Rebase/Text/Printf.hs
+++ b/library/Rebase/Text/Printf.hs
@@ -1,6 +1,0 @@
-module Rebase.Text.Printf
-  ( module Text.Printf,
-  )
-where
-
-import Text.Printf

--- a/library/Rebase/Text/Read.hs
+++ b/library/Rebase/Text/Read.hs
@@ -1,6 +1,0 @@
-module Rebase.Text.Read
-  ( module Text.Read,
-  )
-where
-
-import Text.Read

--- a/library/Rebase/Text/Read/Lex.hs
+++ b/library/Rebase/Text/Read/Lex.hs
@@ -1,6 +1,0 @@
-module Rebase.Text.Read.Lex
-  ( module Text.Read.Lex,
-  )
-where
-
-import Text.Read.Lex

--- a/library/Rebase/Text/Show.hs
+++ b/library/Rebase/Text/Show.hs
@@ -1,6 +1,0 @@
-module Rebase.Text.Show
-  ( module Text.Show,
-  )
-where
-
-import Text.Show

--- a/library/Rebase/Unsafe/Coerce.hs
+++ b/library/Rebase/Unsafe/Coerce.hs
@@ -1,6 +1,0 @@
-module Rebase.Unsafe.Coerce
-  ( module Unsafe.Coerce,
-  )
-where
-
-import Unsafe.Coerce

--- a/rebase.cabal
+++ b/rebase.cabal
@@ -49,374 +49,376 @@ library
 
   default-language:   Haskell2010
   exposed-modules:
-    Rebase.Control.Applicative
-    Rebase.Control.Applicative.Backwards
-    Rebase.Control.Applicative.Lift
-    Rebase.Control.Arrow
-    Rebase.Control.Category
-    Rebase.Control.Comonad
-    Rebase.Control.Concurrent
-    Rebase.Control.Concurrent.Chan
-    Rebase.Control.Concurrent.MVar
-    Rebase.Control.Concurrent.QSem
-    Rebase.Control.Concurrent.QSemN
-    Rebase.Control.Concurrent.STM
-    Rebase.Control.Concurrent.STM.TArray
-    Rebase.Control.Concurrent.STM.TBQueue
-    Rebase.Control.Concurrent.STM.TChan
-    Rebase.Control.Concurrent.STM.TMVar
-    Rebase.Control.Concurrent.STM.TQueue
-    Rebase.Control.Concurrent.STM.TSem
-    Rebase.Control.Concurrent.STM.TVar
-    Rebase.Control.DeepSeq
-    Rebase.Control.Exception
-    Rebase.Control.Exception.Base
-    Rebase.Control.Monad
-    Rebase.Control.Monad.Cont
-    Rebase.Control.Monad.Cont.Class
-    Rebase.Control.Monad.Error.Class
-    Rebase.Control.Monad.Fail
-    Rebase.Control.Monad.Fix
-    Rebase.Control.Monad.Identity
-    Rebase.Control.Monad.IO.Class
-    Rebase.Control.Monad.Reader
-    Rebase.Control.Monad.Reader.Class
-    Rebase.Control.Monad.RWS
-    Rebase.Control.Monad.RWS.Class
-    Rebase.Control.Monad.RWS.Lazy
-    Rebase.Control.Monad.RWS.Strict
-    Rebase.Control.Monad.Signatures
-    Rebase.Control.Monad.ST
-    Rebase.Control.Monad.ST.Lazy
-    Rebase.Control.Monad.ST.Lazy.Unsafe
-    Rebase.Control.Monad.ST.Strict
-    Rebase.Control.Monad.ST.Unsafe
-    Rebase.Control.Monad.State
-    Rebase.Control.Monad.State.Class
-    Rebase.Control.Monad.State.Lazy
-    Rebase.Control.Monad.State.Strict
-    Rebase.Control.Monad.STM
-    Rebase.Control.Monad.Trans
-    Rebase.Control.Monad.Trans.Class
-    Rebase.Control.Monad.Trans.Cont
-    Rebase.Control.Monad.Trans.Except
-    Rebase.Control.Monad.Trans.Identity
-    Rebase.Control.Monad.Trans.Maybe
-    Rebase.Control.Monad.Trans.Reader
-    Rebase.Control.Monad.Trans.RWS
-    Rebase.Control.Monad.Trans.RWS.Lazy
-    Rebase.Control.Monad.Trans.RWS.Strict
-    Rebase.Control.Monad.Trans.State
-    Rebase.Control.Monad.Trans.State.Lazy
-    Rebase.Control.Monad.Trans.State.Strict
-    Rebase.Control.Monad.Trans.Writer
-    Rebase.Control.Monad.Trans.Writer.Lazy
-    Rebase.Control.Monad.Trans.Writer.Strict
-    Rebase.Control.Monad.Writer
-    Rebase.Control.Monad.Writer.Class
-    Rebase.Control.Monad.Writer.Lazy
-    Rebase.Control.Monad.Writer.Strict
-    Rebase.Control.Monad.Zip
-    Rebase.Control.Selective
-    Rebase.Control.Selective.Free
-    Rebase.Control.Selective.Multi
-    Rebase.Control.Selective.Rigid.Free
-    Rebase.Control.Selective.Rigid.Freer
-    Rebase.Data.Biapplicative
-    Rebase.Data.Bifoldable
     Rebase.Data.Bifunctor
-    Rebase.Data.Bifunctor.Apply
-    Rebase.Data.Bifunctor.Biff
-    Rebase.Data.Bifunctor.Clown
-    Rebase.Data.Bifunctor.Flip
-    Rebase.Data.Bifunctor.Join
-    Rebase.Data.Bifunctor.Joker
-    Rebase.Data.Bifunctor.Product
-    Rebase.Data.Bifunctor.Tannen
-    Rebase.Data.Bifunctor.Wrapped
-    Rebase.Data.Bitraversable
-    Rebase.Data.Bits
-    Rebase.Data.Bool
-    Rebase.Data.ByteString
-    Rebase.Data.ByteString.Builder
-    Rebase.Data.ByteString.Builder.Extra
-    Rebase.Data.ByteString.Builder.Internal
-    Rebase.Data.ByteString.Builder.Prim
-    Rebase.Data.ByteString.Builder.Prim.Internal
-    Rebase.Data.ByteString.Builder.Scientific
-    Rebase.Data.ByteString.Char8
-    Rebase.Data.ByteString.Internal
-    Rebase.Data.ByteString.Lazy
-    Rebase.Data.ByteString.Lazy.Char8
-    Rebase.Data.ByteString.Lazy.Internal
-    Rebase.Data.ByteString.Short
-    Rebase.Data.ByteString.Short.Internal
-    Rebase.Data.ByteString.Unsafe
-    Rebase.Data.Char
-    Rebase.Data.Coerce
-    Rebase.Data.Complex
-    Rebase.Data.Data
-    Rebase.Data.DList
-    Rebase.Data.Dynamic
-    Rebase.Data.Either
-    Rebase.Data.Either.Combinators
-    Rebase.Data.Either.Validation
-    Rebase.Data.Eq
-    Rebase.Data.Fixed
-    Rebase.Data.Foldable
-    Rebase.Data.Function
-    Rebase.Data.Functor
-    Rebase.Data.Functor.Alt
-    Rebase.Data.Functor.Apply
-    Rebase.Data.Functor.Bind
-    Rebase.Data.Functor.Bind.Class
-    Rebase.Data.Functor.Bind.Trans
-    Rebase.Data.Functor.Classes
-    Rebase.Data.Functor.Compose
-    Rebase.Data.Functor.Constant
-    Rebase.Data.Functor.Contravariant
-    Rebase.Data.Functor.Contravariant.Compose
-    Rebase.Data.Functor.Contravariant.Divisible
-    Rebase.Data.Functor.Extend
-    Rebase.Data.Functor.Identity
-    Rebase.Data.Functor.Invariant
-    Rebase.Data.Functor.Invariant.TH
-    Rebase.Data.Functor.Plus
-    Rebase.Data.Functor.Product
-    Rebase.Data.Functor.Reverse
-    Rebase.Data.Functor.Sum
-    Rebase.Data.Graph
-    Rebase.Data.Group
-    Rebase.Data.Groupoid
-    Rebase.Data.Hashable
-    Rebase.Data.HashMap.Lazy
-    Rebase.Data.HashMap.Strict
-    Rebase.Data.HashSet
-    Rebase.Data.Int
-    Rebase.Data.IntMap
-    Rebase.Data.IntMap.Lazy
-    Rebase.Data.IntMap.Strict
-    Rebase.Data.IntSet
-    Rebase.Data.IORef
-    Rebase.Data.Isomorphism
-    Rebase.Data.Ix
-    Rebase.Data.Kind
-    Rebase.Data.List
-    Rebase.Data.List.NonEmpty
-    Rebase.Data.Map
-    Rebase.Data.Map.Lazy
-    Rebase.Data.Map.Strict
-    Rebase.Data.Maybe
-    Rebase.Data.Monoid
-    Rebase.Data.Ord
-    Rebase.Data.Profunctor
-    Rebase.Data.Profunctor.Adjunction
-    Rebase.Data.Profunctor.Cayley
-    Rebase.Data.Profunctor.Choice
-    Rebase.Data.Profunctor.Closed
-    Rebase.Data.Profunctor.Composition
-    Rebase.Data.Profunctor.Mapping
-    Rebase.Data.Profunctor.Monad
-    Rebase.Data.Profunctor.Ran
-    Rebase.Data.Profunctor.Rep
-    Rebase.Data.Profunctor.Sieve
-    Rebase.Data.Profunctor.Strong
-    Rebase.Data.Profunctor.Traversing
-    Rebase.Data.Profunctor.Types
-    Rebase.Data.Profunctor.Unsafe
-    Rebase.Data.Profunctor.Yoneda
-    Rebase.Data.Proxy
-    Rebase.Data.Ratio
-    Rebase.Data.Scientific
-    Rebase.Data.Semigroup
-    Rebase.Data.Semigroup.Bifoldable
-    Rebase.Data.Semigroup.Bitraversable
-    Rebase.Data.Semigroup.Foldable
-    Rebase.Data.Semigroup.Traversable
-    Rebase.Data.Semigroup.Traversable.Class
-    Rebase.Data.Semigroupoid
-    Rebase.Data.Semigroupoid.Dual
-    Rebase.Data.Semigroupoid.Ob
-    Rebase.Data.Semigroupoid.Static
-    Rebase.Data.Sequence
-    Rebase.Data.Set
-    Rebase.Data.STRef
-    Rebase.Data.STRef.Lazy
-    Rebase.Data.STRef.Strict
-    Rebase.Data.String
     Rebase.Data.Text
-    Rebase.Data.Text.Array
-    Rebase.Data.Text.Encoding
-    Rebase.Data.Text.Encoding.Error
-    Rebase.Data.Text.Foreign
-    Rebase.Data.Text.Internal
-    Rebase.Data.Text.IO
     Rebase.Data.Text.Lazy
-    Rebase.Data.Text.Lazy.Builder
-    Rebase.Data.Text.Lazy.Builder.Int
-    Rebase.Data.Text.Lazy.Builder.RealFloat
-    Rebase.Data.Text.Lazy.Builder.Scientific
-    Rebase.Data.Text.Lazy.Encoding
-    Rebase.Data.Text.Lazy.IO
-    Rebase.Data.Text.Lazy.Read
-    Rebase.Data.Text.Read
-    Rebase.Data.Text.Unsafe
-    Rebase.Data.Time
-    Rebase.Data.Time.Calendar
-    Rebase.Data.Time.Calendar.Easter
-    Rebase.Data.Time.Calendar.Julian
-    Rebase.Data.Time.Calendar.MonthDay
-    Rebase.Data.Time.Calendar.OrdinalDate
-    Rebase.Data.Time.Calendar.WeekDate
-    Rebase.Data.Time.Clock
-    Rebase.Data.Time.Clock.POSIX
-    Rebase.Data.Time.Clock.System
-    Rebase.Data.Time.Clock.TAI
-    Rebase.Data.Time.Compat
-    Rebase.Data.Time.Format
-    Rebase.Data.Time.Format.ISO8601
-    Rebase.Data.Time.LocalTime
-    Rebase.Data.Traversable
-    Rebase.Data.Traversable.Instances
-    Rebase.Data.Tree
-    Rebase.Data.Tuple
-    Rebase.Data.Type.Bool
-    Rebase.Data.Type.Coercion
-    Rebase.Data.Type.Equality
-    Rebase.Data.Typeable
-    Rebase.Data.Unique
-    Rebase.Data.UUID
-    Rebase.Data.Vector
-    Rebase.Data.Vector.Fusion.Stream.Monadic
-    Rebase.Data.Vector.Fusion.Util
-    Rebase.Data.Vector.Generic
-    Rebase.Data.Vector.Generic.Base
-    Rebase.Data.Vector.Generic.Mutable
-    Rebase.Data.Vector.Generic.New
-    Rebase.Data.Vector.Instances
-    Rebase.Data.Vector.Internal.Check
-    Rebase.Data.Vector.Mutable
-    Rebase.Data.Vector.Primitive
-    Rebase.Data.Vector.Primitive.Mutable
-    Rebase.Data.Vector.Storable
-    Rebase.Data.Vector.Storable.Internal
-    Rebase.Data.Vector.Storable.Mutable
-    Rebase.Data.Vector.Unboxed
-    Rebase.Data.Vector.Unboxed.Base
-    Rebase.Data.Vector.Unboxed.Mutable
-    Rebase.Data.Version
-    Rebase.Data.Void
-    Rebase.Data.Void.Unsafe
-    Rebase.Data.Word
-    Rebase.Debug.Trace
-    Rebase.Foreign
-    Rebase.Foreign.C
-    Rebase.Foreign.C.Error
-    Rebase.Foreign.C.String
-    Rebase.Foreign.C.Types
-    Rebase.Foreign.Concurrent
-    Rebase.Foreign.ForeignPtr
-    Rebase.Foreign.ForeignPtr.Unsafe
-    Rebase.Foreign.Marshal
-    Rebase.Foreign.Marshal.Alloc
-    Rebase.Foreign.Marshal.Array
-    Rebase.Foreign.Marshal.Error
-    Rebase.Foreign.Marshal.Pool
-    Rebase.Foreign.Marshal.Safe
-    Rebase.Foreign.Marshal.Unsafe
-    Rebase.Foreign.Marshal.Utils
-    Rebase.Foreign.Ptr
-    Rebase.Foreign.StablePtr
-    Rebase.Foreign.Storable
-    Rebase.GHC.Arr
-    Rebase.GHC.Base
-    Rebase.GHC.Char
-    Rebase.GHC.Conc
-    Rebase.GHC.Conc.IO
-    Rebase.GHC.Conc.Signal
-    Rebase.GHC.Conc.Sync
-    Rebase.GHC.Enum
-    Rebase.GHC.Environment
-    Rebase.GHC.Err
-    Rebase.GHC.Exception
-    Rebase.GHC.Exts
-    Rebase.GHC.Fingerprint
-    Rebase.GHC.Fingerprint.Type
-    Rebase.GHC.Float
-    Rebase.GHC.Float.ConversionUtils
-    Rebase.GHC.Float.RealFracMethods
-    Rebase.GHC.Foreign
-    Rebase.GHC.ForeignPtr
-    Rebase.GHC.Generics
-    Rebase.GHC.Int
-    Rebase.GHC.IO
-    Rebase.GHC.IO.Buffer
-    Rebase.GHC.IO.BufferedIO
-    Rebase.GHC.IO.Device
-    Rebase.GHC.IO.Encoding
-    Rebase.GHC.IO.Encoding.Failure
-    Rebase.GHC.IO.Encoding.Iconv
-    Rebase.GHC.IO.Encoding.Latin1
-    Rebase.GHC.IO.Encoding.Types
-    Rebase.GHC.IO.Encoding.UTF16
-    Rebase.GHC.IO.Encoding.UTF32
-    Rebase.GHC.IO.Encoding.UTF8
-    Rebase.GHC.IO.Exception
-    Rebase.GHC.IO.FD
-    Rebase.GHC.IO.Handle
-    Rebase.GHC.IO.Handle.FD
-    Rebase.GHC.IO.Handle.Internals
-    Rebase.GHC.IO.Handle.Text
-    Rebase.GHC.IO.Handle.Types
-    Rebase.GHC.IO.IOMode
-    Rebase.GHC.IOArray
-    Rebase.GHC.IORef
-    Rebase.GHC.List
-    Rebase.GHC.MVar
-    Rebase.GHC.Num
-    Rebase.GHC.OverloadedLabels
-    Rebase.GHC.Profiling
-    Rebase.GHC.Ptr
-    Rebase.GHC.Read
-    Rebase.GHC.Real
-    Rebase.GHC.Records
-    Rebase.GHC.Show
-    Rebase.GHC.ST
-    Rebase.GHC.Stable
-    Rebase.GHC.Stack
-    Rebase.GHC.Stats
-    Rebase.GHC.Storable
-    Rebase.GHC.STRef
-    Rebase.GHC.TopHandler
-    Rebase.GHC.TypeLits
-    Rebase.GHC.TypeNats
-    Rebase.GHC.Unicode
-    Rebase.GHC.Weak
-    Rebase.GHC.Word
-    Rebase.Numeric
-    Rebase.Numeric.Natural
     Rebase.Prelude
-    Rebase.System.Console.GetOpt
-    Rebase.System.CPUTime
-    Rebase.System.Environment
-    Rebase.System.Exit
-    Rebase.System.Info
-    Rebase.System.IO
-    Rebase.System.IO.Error
-    Rebase.System.IO.Unsafe
-    Rebase.System.Mem
-    Rebase.System.Mem.StableName
-    Rebase.System.Mem.Weak
-    Rebase.System.Posix.Internals
-    Rebase.System.Posix.Types
-    Rebase.System.Timeout
-    Rebase.Text.ParserCombinators.ReadP
-    Rebase.Text.ParserCombinators.ReadPrec
-    Rebase.Text.Printf
-    Rebase.Text.Read
-    Rebase.Text.Read.Lex
-    Rebase.Text.Show
-    Rebase.Unsafe.Coerce
+  reexported-modules:
+    Control.Applicative as Rebase.Control.Applicative,
+    Control.Applicative.Backwards as Rebase.Control.Applicative.Backwards,
+    Control.Applicative.Lift as Rebase.Control.Applicative.Lift,
+    Control.Arrow as Rebase.Control.Arrow,
+    Control.Category as Rebase.Control.Category,
+    Control.Comonad as Rebase.Control.Comonad,
+    Control.Concurrent as Rebase.Control.Concurrent,
+    Control.Concurrent.Chan as Rebase.Control.Concurrent.Chan,
+    Control.Concurrent.MVar as Rebase.Control.Concurrent.MVar,
+    Control.Concurrent.QSem as Rebase.Control.Concurrent.QSem,
+    Control.Concurrent.QSemN as Rebase.Control.Concurrent.QSemN,
+    Control.Concurrent.STM as Rebase.Control.Concurrent.STM,
+    Control.Concurrent.STM.TArray as Rebase.Control.Concurrent.STM.TArray,
+    Control.Concurrent.STM.TBQueue as Rebase.Control.Concurrent.STM.TBQueue,
+    Control.Concurrent.STM.TChan as Rebase.Control.Concurrent.STM.TChan,
+    Control.Concurrent.STM.TMVar as Rebase.Control.Concurrent.STM.TMVar,
+    Control.Concurrent.STM.TQueue as Rebase.Control.Concurrent.STM.TQueue,
+    Control.Concurrent.STM.TSem as Rebase.Control.Concurrent.STM.TSem,
+    Control.Concurrent.STM.TVar as Rebase.Control.Concurrent.STM.TVar,
+    Control.DeepSeq as Rebase.Control.DeepSeq,
+    Control.Exception as Rebase.Control.Exception,
+    Control.Exception.Base as Rebase.Control.Exception.Base,
+    Control.Monad as Rebase.Control.Monad,
+    Control.Monad.Cont as Rebase.Control.Monad.Cont,
+    Control.Monad.Cont.Class as Rebase.Control.Monad.Cont.Class,
+    Control.Monad.Error.Class as Rebase.Control.Monad.Error.Class,
+    Control.Monad.Fail as Rebase.Control.Monad.Fail,
+    Control.Monad.Fix as Rebase.Control.Monad.Fix,
+    Control.Monad.Identity as Rebase.Control.Monad.Identity,
+    Control.Monad.IO.Class as Rebase.Control.Monad.IO.Class,
+    Control.Monad.Reader as Rebase.Control.Monad.Reader,
+    Control.Monad.Reader.Class as Rebase.Control.Monad.Reader.Class,
+    Control.Monad.RWS as Rebase.Control.Monad.RWS,
+    Control.Monad.RWS.Class as Rebase.Control.Monad.RWS.Class,
+    Control.Monad.RWS.Lazy as Rebase.Control.Monad.RWS.Lazy,
+    Control.Monad.RWS.Strict as Rebase.Control.Monad.RWS.Strict,
+    Control.Monad.Signatures as Rebase.Control.Monad.Signatures,
+    Control.Monad.ST as Rebase.Control.Monad.ST,
+    Control.Monad.ST.Lazy as Rebase.Control.Monad.ST.Lazy,
+    Control.Monad.ST.Lazy.Unsafe as Rebase.Control.Monad.ST.Lazy.Unsafe,
+    Control.Monad.ST.Strict as Rebase.Control.Monad.ST.Strict,
+    Control.Monad.ST.Unsafe as Rebase.Control.Monad.ST.Unsafe,
+    Control.Monad.State as Rebase.Control.Monad.State,
+    Control.Monad.State.Class as Rebase.Control.Monad.State.Class,
+    Control.Monad.State.Lazy as Rebase.Control.Monad.State.Lazy,
+    Control.Monad.State.Strict as Rebase.Control.Monad.State.Strict,
+    Control.Monad.STM as Rebase.Control.Monad.STM,
+    Control.Monad.Trans as Rebase.Control.Monad.Trans,
+    Control.Monad.Trans.Class as Rebase.Control.Monad.Trans.Class,
+    Control.Monad.Trans.Cont as Rebase.Control.Monad.Trans.Cont,
+    Control.Monad.Trans.Except as Rebase.Control.Monad.Trans.Except,
+    Control.Monad.Trans.Identity as Rebase.Control.Monad.Trans.Identity,
+    Control.Monad.Trans.Maybe as Rebase.Control.Monad.Trans.Maybe,
+    Control.Monad.Trans.Reader as Rebase.Control.Monad.Trans.Reader,
+    Control.Monad.Trans.RWS as Rebase.Control.Monad.Trans.RWS,
+    Control.Monad.Trans.RWS.Lazy as Rebase.Control.Monad.Trans.RWS.Lazy,
+    Control.Monad.Trans.RWS.Strict as Rebase.Control.Monad.Trans.RWS.Strict,
+    Control.Monad.Trans.State as Rebase.Control.Monad.Trans.State,
+    Control.Monad.Trans.State.Lazy as Rebase.Control.Monad.Trans.State.Lazy,
+    Control.Monad.Trans.State.Strict as Rebase.Control.Monad.Trans.State.Strict,
+    Control.Monad.Trans.Writer as Rebase.Control.Monad.Trans.Writer,
+    Control.Monad.Trans.Writer.Lazy as Rebase.Control.Monad.Trans.Writer.Lazy,
+    Control.Monad.Trans.Writer.Strict as Rebase.Control.Monad.Trans.Writer.Strict,
+    Control.Monad.Writer as Rebase.Control.Monad.Writer,
+    Control.Monad.Writer.Class as Rebase.Control.Monad.Writer.Class,
+    Control.Monad.Writer.Lazy as Rebase.Control.Monad.Writer.Lazy,
+    Control.Monad.Writer.Strict as Rebase.Control.Monad.Writer.Strict,
+    Control.Monad.Zip as Rebase.Control.Monad.Zip,
+    Control.Selective as Rebase.Control.Selective,
+    Control.Selective.Free as Rebase.Control.Selective.Free,
+    Control.Selective.Multi as Rebase.Control.Selective.Multi,
+    Control.Selective.Rigid.Free as Rebase.Control.Selective.Rigid.Free,
+    Control.Selective.Rigid.Freer as Rebase.Control.Selective.Rigid.Freer,
+    Data.Biapplicative as Rebase.Data.Biapplicative,
+    Data.Bifoldable as Rebase.Data.Bifoldable,
+    Data.Bifunctor.Apply as Rebase.Data.Bifunctor.Apply,
+    Data.Bifunctor.Biff as Rebase.Data.Bifunctor.Biff,
+    Data.Bifunctor.Clown as Rebase.Data.Bifunctor.Clown,
+    Data.Bifunctor.Flip as Rebase.Data.Bifunctor.Flip,
+    Data.Bifunctor.Join as Rebase.Data.Bifunctor.Join,
+    Data.Bifunctor.Joker as Rebase.Data.Bifunctor.Joker,
+    Data.Bifunctor.Product as Rebase.Data.Bifunctor.Product,
+    Data.Bifunctor.Tannen as Rebase.Data.Bifunctor.Tannen,
+    Data.Bifunctor.Wrapped as Rebase.Data.Bifunctor.Wrapped,
+    Data.Bitraversable as Rebase.Data.Bitraversable,
+    Data.Bits as Rebase.Data.Bits,
+    Data.Bool as Rebase.Data.Bool,
+    Data.ByteString as Rebase.Data.ByteString,
+    Data.ByteString.Builder as Rebase.Data.ByteString.Builder,
+    Data.ByteString.Builder.Extra as Rebase.Data.ByteString.Builder.Extra,
+    Data.ByteString.Builder.Internal as Rebase.Data.ByteString.Builder.Internal,
+    Data.ByteString.Builder.Prim as Rebase.Data.ByteString.Builder.Prim,
+    Data.ByteString.Builder.Prim.Internal as Rebase.Data.ByteString.Builder.Prim.Internal,
+    Data.ByteString.Builder.Scientific as Rebase.Data.ByteString.Builder.Scientific,
+    Data.ByteString.Char8 as Rebase.Data.ByteString.Char8,
+    Data.ByteString.Internal as Rebase.Data.ByteString.Internal,
+    Data.ByteString.Lazy as Rebase.Data.ByteString.Lazy,
+    Data.ByteString.Lazy.Char8 as Rebase.Data.ByteString.Lazy.Char8,
+    Data.ByteString.Lazy.Internal as Rebase.Data.ByteString.Lazy.Internal,
+    Data.ByteString.Short as Rebase.Data.ByteString.Short,
+    Data.ByteString.Short.Internal as Rebase.Data.ByteString.Short.Internal,
+    Data.ByteString.Unsafe as Rebase.Data.ByteString.Unsafe,
+    Data.Char as Rebase.Data.Char,
+    Data.Coerce as Rebase.Data.Coerce,
+    Data.Complex as Rebase.Data.Complex,
+    Data.Data as Rebase.Data.Data,
+    Data.DList as Rebase.Data.DList,
+    Data.Dynamic as Rebase.Data.Dynamic,
+    Data.Either as Rebase.Data.Either,
+    Data.Either.Combinators as Rebase.Data.Either.Combinators,
+    Data.Either.Validation as Rebase.Data.Either.Validation,
+    Data.Eq as Rebase.Data.Eq,
+    Data.Fixed as Rebase.Data.Fixed,
+    Data.Foldable as Rebase.Data.Foldable,
+    Data.Function as Rebase.Data.Function,
+    Data.Functor as Rebase.Data.Functor,
+    Data.Functor.Alt as Rebase.Data.Functor.Alt,
+    Data.Functor.Apply as Rebase.Data.Functor.Apply,
+    Data.Functor.Bind as Rebase.Data.Functor.Bind,
+    Data.Functor.Bind.Class as Rebase.Data.Functor.Bind.Class,
+    Data.Functor.Bind.Trans as Rebase.Data.Functor.Bind.Trans,
+    Data.Functor.Classes as Rebase.Data.Functor.Classes,
+    Data.Functor.Compose as Rebase.Data.Functor.Compose,
+    Data.Functor.Constant as Rebase.Data.Functor.Constant,
+    Data.Functor.Contravariant as Rebase.Data.Functor.Contravariant,
+    Data.Functor.Contravariant.Compose as Rebase.Data.Functor.Contravariant.Compose,
+    Data.Functor.Contravariant.Divisible as Rebase.Data.Functor.Contravariant.Divisible,
+    Data.Functor.Extend as Rebase.Data.Functor.Extend,
+    Data.Functor.Identity as Rebase.Data.Functor.Identity,
+    Data.Functor.Invariant as Rebase.Data.Functor.Invariant,
+    Data.Functor.Invariant.TH as Rebase.Data.Functor.Invariant.TH,
+    Data.Functor.Plus as Rebase.Data.Functor.Plus,
+    Data.Functor.Product as Rebase.Data.Functor.Product,
+    Data.Functor.Reverse as Rebase.Data.Functor.Reverse,
+    Data.Functor.Sum as Rebase.Data.Functor.Sum,
+    Data.Graph as Rebase.Data.Graph,
+    Data.Group as Rebase.Data.Group,
+    Data.Groupoid as Rebase.Data.Groupoid,
+    Data.Hashable as Rebase.Data.Hashable,
+    Data.HashMap.Lazy as Rebase.Data.HashMap.Lazy,
+    Data.HashMap.Strict as Rebase.Data.HashMap.Strict,
+    Data.HashSet as Rebase.Data.HashSet,
+    Data.Int as Rebase.Data.Int,
+    Data.IntMap as Rebase.Data.IntMap,
+    Data.IntMap.Lazy as Rebase.Data.IntMap.Lazy,
+    Data.IntMap.Strict as Rebase.Data.IntMap.Strict,
+    Data.IntSet as Rebase.Data.IntSet,
+    Data.IORef as Rebase.Data.IORef,
+    Data.Isomorphism as Rebase.Data.Isomorphism,
+    Data.Ix as Rebase.Data.Ix,
+    Data.Kind as Rebase.Data.Kind,
+    Data.List as Rebase.Data.List,
+    Data.List.NonEmpty as Rebase.Data.List.NonEmpty,
+    Data.Map as Rebase.Data.Map,
+    Data.Map.Lazy as Rebase.Data.Map.Lazy,
+    Data.Map.Strict as Rebase.Data.Map.Strict,
+    Data.Maybe as Rebase.Data.Maybe,
+    Data.Monoid as Rebase.Data.Monoid,
+    Data.Ord as Rebase.Data.Ord,
+    Data.Profunctor as Rebase.Data.Profunctor,
+    Data.Profunctor.Adjunction as Rebase.Data.Profunctor.Adjunction,
+    Data.Profunctor.Cayley as Rebase.Data.Profunctor.Cayley,
+    Data.Profunctor.Choice as Rebase.Data.Profunctor.Choice,
+    Data.Profunctor.Closed as Rebase.Data.Profunctor.Closed,
+    Data.Profunctor.Composition as Rebase.Data.Profunctor.Composition,
+    Data.Profunctor.Mapping as Rebase.Data.Profunctor.Mapping,
+    Data.Profunctor.Monad as Rebase.Data.Profunctor.Monad,
+    Data.Profunctor.Ran as Rebase.Data.Profunctor.Ran,
+    Data.Profunctor.Rep as Rebase.Data.Profunctor.Rep,
+    Data.Profunctor.Sieve as Rebase.Data.Profunctor.Sieve,
+    Data.Profunctor.Strong as Rebase.Data.Profunctor.Strong,
+    Data.Profunctor.Traversing as Rebase.Data.Profunctor.Traversing,
+    Data.Profunctor.Types as Rebase.Data.Profunctor.Types,
+    Data.Profunctor.Unsafe as Rebase.Data.Profunctor.Unsafe,
+    Data.Profunctor.Yoneda as Rebase.Data.Profunctor.Yoneda,
+    Data.Proxy as Rebase.Data.Proxy,
+    Data.Ratio as Rebase.Data.Ratio,
+    Data.Scientific as Rebase.Data.Scientific,
+    Data.Semigroup as Rebase.Data.Semigroup,
+    Data.Semigroup.Bifoldable as Rebase.Data.Semigroup.Bifoldable,
+    Data.Semigroup.Bitraversable as Rebase.Data.Semigroup.Bitraversable,
+    Data.Semigroup.Foldable as Rebase.Data.Semigroup.Foldable,
+    Data.Semigroup.Traversable as Rebase.Data.Semigroup.Traversable,
+    Data.Semigroup.Traversable.Class as Rebase.Data.Semigroup.Traversable.Class,
+    Data.Semigroupoid as Rebase.Data.Semigroupoid,
+    Data.Semigroupoid.Dual as Rebase.Data.Semigroupoid.Dual,
+    Data.Semigroupoid.Ob as Rebase.Data.Semigroupoid.Ob,
+    Data.Semigroupoid.Static as Rebase.Data.Semigroupoid.Static,
+    Data.Sequence as Rebase.Data.Sequence,
+    Data.Set as Rebase.Data.Set,
+    Data.STRef as Rebase.Data.STRef,
+    Data.STRef.Lazy as Rebase.Data.STRef.Lazy,
+    Data.STRef.Strict as Rebase.Data.STRef.Strict,
+    Data.String as Rebase.Data.String,
+    Data.Text.Array as Rebase.Data.Text.Array,
+    Data.Text.Encoding as Rebase.Data.Text.Encoding,
+    Data.Text.Encoding.Error as Rebase.Data.Text.Encoding.Error,
+    Data.Text.Foreign as Rebase.Data.Text.Foreign,
+    Data.Text.Internal as Rebase.Data.Text.Internal,
+    Data.Text.IO as Rebase.Data.Text.IO,
+    Data.Text.Lazy.Builder as Rebase.Data.Text.Lazy.Builder,
+    Data.Text.Lazy.Builder.Int as Rebase.Data.Text.Lazy.Builder.Int,
+    Data.Text.Lazy.Builder.RealFloat as Rebase.Data.Text.Lazy.Builder.RealFloat,
+    Data.Text.Lazy.Builder.Scientific as Rebase.Data.Text.Lazy.Builder.Scientific,
+    Data.Text.Lazy.Encoding as Rebase.Data.Text.Lazy.Encoding,
+    Data.Text.Lazy.IO as Rebase.Data.Text.Lazy.IO,
+    Data.Text.Lazy.Read as Rebase.Data.Text.Lazy.Read,
+    Data.Text.Read as Rebase.Data.Text.Read,
+    Data.Text.Unsafe as Rebase.Data.Text.Unsafe,
+    Data.Time as Rebase.Data.Time,
+    Data.Time.Calendar as Rebase.Data.Time.Calendar,
+    Data.Time.Calendar.Easter as Rebase.Data.Time.Calendar.Easter,
+    Data.Time.Calendar.Julian as Rebase.Data.Time.Calendar.Julian,
+    Data.Time.Calendar.MonthDay as Rebase.Data.Time.Calendar.MonthDay,
+    Data.Time.Calendar.OrdinalDate as Rebase.Data.Time.Calendar.OrdinalDate,
+    Data.Time.Calendar.WeekDate as Rebase.Data.Time.Calendar.WeekDate,
+    Data.Time.Clock as Rebase.Data.Time.Clock,
+    Data.Time.Clock.POSIX as Rebase.Data.Time.Clock.POSIX,
+    Data.Time.Clock.System as Rebase.Data.Time.Clock.System,
+    Data.Time.Clock.TAI as Rebase.Data.Time.Clock.TAI,
+    Data.Time.Compat as Rebase.Data.Time.Compat,
+    Data.Time.Format as Rebase.Data.Time.Format,
+    Data.Time.Format.ISO8601 as Rebase.Data.Time.Format.ISO8601,
+    Data.Time.LocalTime as Rebase.Data.Time.LocalTime,
+    Data.Traversable as Rebase.Data.Traversable,
+    Data.Traversable.Instances as Rebase.Data.Traversable.Instances,
+    Data.Tree as Rebase.Data.Tree,
+    Data.Tuple as Rebase.Data.Tuple,
+    Data.Type.Bool as Rebase.Data.Type.Bool,
+    Data.Type.Coercion as Rebase.Data.Type.Coercion,
+    Data.Type.Equality as Rebase.Data.Type.Equality,
+    Data.Typeable as Rebase.Data.Typeable,
+    Data.Unique as Rebase.Data.Unique,
+    -- note rename
+    Data.UUID.Types as Rebase.Data.UUID,
+    Data.Vector as Rebase.Data.Vector,
+    Data.Vector.Fusion.Stream.Monadic as Rebase.Data.Vector.Fusion.Stream.Monadic,
+    Data.Vector.Fusion.Util as Rebase.Data.Vector.Fusion.Util,
+    Data.Vector.Generic as Rebase.Data.Vector.Generic,
+    Data.Vector.Generic.Base as Rebase.Data.Vector.Generic.Base,
+    Data.Vector.Generic.Mutable as Rebase.Data.Vector.Generic.Mutable,
+    Data.Vector.Generic.New as Rebase.Data.Vector.Generic.New,
+    Data.Vector.Instances as Rebase.Data.Vector.Instances,
+    Data.Vector.Internal.Check as Rebase.Data.Vector.Internal.Check,
+    Data.Vector.Mutable as Rebase.Data.Vector.Mutable,
+    Data.Vector.Primitive as Rebase.Data.Vector.Primitive,
+    Data.Vector.Primitive.Mutable as Rebase.Data.Vector.Primitive.Mutable,
+    Data.Vector.Storable as Rebase.Data.Vector.Storable,
+    Data.Vector.Storable.Internal as Rebase.Data.Vector.Storable.Internal,
+    Data.Vector.Storable.Mutable as Rebase.Data.Vector.Storable.Mutable,
+    Data.Vector.Unboxed as Rebase.Data.Vector.Unboxed,
+    Data.Vector.Unboxed.Base as Rebase.Data.Vector.Unboxed.Base,
+    Data.Vector.Unboxed.Mutable as Rebase.Data.Vector.Unboxed.Mutable,
+    Data.Version as Rebase.Data.Version,
+    Data.Void as Rebase.Data.Void,
+    Data.Void.Unsafe as Rebase.Data.Void.Unsafe,
+    Data.Word as Rebase.Data.Word,
+    Debug.Trace as Rebase.Debug.Trace,
+    Foreign as Rebase.Foreign,
+    Foreign.C as Rebase.Foreign.C,
+    Foreign.C.Error as Rebase.Foreign.C.Error,
+    Foreign.C.String as Rebase.Foreign.C.String,
+    Foreign.C.Types as Rebase.Foreign.C.Types,
+    Foreign.Concurrent as Rebase.Foreign.Concurrent,
+    Foreign.ForeignPtr as Rebase.Foreign.ForeignPtr,
+    Foreign.ForeignPtr.Unsafe as Rebase.Foreign.ForeignPtr.Unsafe,
+    Foreign.Marshal as Rebase.Foreign.Marshal,
+    Foreign.Marshal.Alloc as Rebase.Foreign.Marshal.Alloc,
+    Foreign.Marshal.Array as Rebase.Foreign.Marshal.Array,
+    Foreign.Marshal.Error as Rebase.Foreign.Marshal.Error,
+    Foreign.Marshal.Pool as Rebase.Foreign.Marshal.Pool,
+    Foreign.Marshal.Safe as Rebase.Foreign.Marshal.Safe,
+    Foreign.Marshal.Unsafe as Rebase.Foreign.Marshal.Unsafe,
+    Foreign.Marshal.Utils as Rebase.Foreign.Marshal.Utils,
+    Foreign.Ptr as Rebase.Foreign.Ptr,
+    Foreign.StablePtr as Rebase.Foreign.StablePtr,
+    Foreign.Storable as Rebase.Foreign.Storable,
+    GHC.Arr as Rebase.GHC.Arr,
+    GHC.Base as Rebase.GHC.Base,
+    GHC.Char as Rebase.GHC.Char,
+    GHC.Conc as Rebase.GHC.Conc,
+    GHC.Conc.IO as Rebase.GHC.Conc.IO,
+    GHC.Conc.Signal as Rebase.GHC.Conc.Signal,
+    GHC.Conc.Sync as Rebase.GHC.Conc.Sync,
+    GHC.Enum as Rebase.GHC.Enum,
+    GHC.Environment as Rebase.GHC.Environment,
+    GHC.Err as Rebase.GHC.Err,
+    GHC.Exception as Rebase.GHC.Exception,
+    GHC.Exts as Rebase.GHC.Exts,
+    GHC.Fingerprint as Rebase.GHC.Fingerprint,
+    GHC.Fingerprint.Type as Rebase.GHC.Fingerprint.Type,
+    GHC.Float as Rebase.GHC.Float,
+    GHC.Float.ConversionUtils as Rebase.GHC.Float.ConversionUtils,
+    GHC.Float.RealFracMethods as Rebase.GHC.Float.RealFracMethods,
+    GHC.Foreign as Rebase.GHC.Foreign,
+    GHC.ForeignPtr as Rebase.GHC.ForeignPtr,
+    GHC.Generics as Rebase.GHC.Generics,
+    GHC.Int as Rebase.GHC.Int,
+    GHC.IO as Rebase.GHC.IO,
+    GHC.IO.Buffer as Rebase.GHC.IO.Buffer,
+    GHC.IO.BufferedIO as Rebase.GHC.IO.BufferedIO,
+    GHC.IO.Device as Rebase.GHC.IO.Device,
+    GHC.IO.Encoding as Rebase.GHC.IO.Encoding,
+    GHC.IO.Encoding.Failure as Rebase.GHC.IO.Encoding.Failure,
+    GHC.IO.Encoding.Iconv as Rebase.GHC.IO.Encoding.Iconv,
+    GHC.IO.Encoding.Latin1 as Rebase.GHC.IO.Encoding.Latin1,
+    GHC.IO.Encoding.Types as Rebase.GHC.IO.Encoding.Types,
+    GHC.IO.Encoding.UTF16 as Rebase.GHC.IO.Encoding.UTF16,
+    GHC.IO.Encoding.UTF32 as Rebase.GHC.IO.Encoding.UTF32,
+    GHC.IO.Encoding.UTF8 as Rebase.GHC.IO.Encoding.UTF8,
+    GHC.IO.Exception as Rebase.GHC.IO.Exception,
+    GHC.IO.FD as Rebase.GHC.IO.FD,
+    GHC.IO.Handle as Rebase.GHC.IO.Handle,
+    GHC.IO.Handle.FD as Rebase.GHC.IO.Handle.FD,
+    GHC.IO.Handle.Internals as Rebase.GHC.IO.Handle.Internals,
+    GHC.IO.Handle.Text as Rebase.GHC.IO.Handle.Text,
+    GHC.IO.Handle.Types as Rebase.GHC.IO.Handle.Types,
+    GHC.IO.IOMode as Rebase.GHC.IO.IOMode,
+    GHC.IOArray as Rebase.GHC.IOArray,
+    GHC.IORef as Rebase.GHC.IORef,
+    GHC.List as Rebase.GHC.List,
+    GHC.MVar as Rebase.GHC.MVar,
+    GHC.Num as Rebase.GHC.Num,
+    GHC.OverloadedLabels as Rebase.GHC.OverloadedLabels,
+    GHC.Profiling as Rebase.GHC.Profiling,
+    GHC.Ptr as Rebase.GHC.Ptr,
+    GHC.Read as Rebase.GHC.Read,
+    GHC.Real as Rebase.GHC.Real,
+    GHC.Records as Rebase.GHC.Records,
+    GHC.Show as Rebase.GHC.Show,
+    GHC.ST as Rebase.GHC.ST,
+    GHC.Stable as Rebase.GHC.Stable,
+    GHC.Stack as Rebase.GHC.Stack,
+    GHC.Stats as Rebase.GHC.Stats,
+    GHC.Storable as Rebase.GHC.Storable,
+    GHC.STRef as Rebase.GHC.STRef,
+    GHC.TopHandler as Rebase.GHC.TopHandler,
+    GHC.TypeLits as Rebase.GHC.TypeLits,
+    GHC.TypeNats as Rebase.GHC.TypeNats,
+    GHC.Unicode as Rebase.GHC.Unicode,
+    GHC.Weak as Rebase.GHC.Weak,
+    GHC.Word as Rebase.GHC.Word,
+    Numeric as Rebase.Numeric,
+    Numeric.Natural as Rebase.Numeric.Natural,
+    System.Console.GetOpt as Rebase.System.Console.GetOpt,
+    System.CPUTime as Rebase.System.CPUTime,
+    System.Environment as Rebase.System.Environment,
+    System.Exit as Rebase.System.Exit,
+    System.Info as Rebase.System.Info,
+    System.IO as Rebase.System.IO,
+    System.IO.Error as Rebase.System.IO.Error,
+    System.IO.Unsafe as Rebase.System.IO.Unsafe,
+    System.Mem as Rebase.System.Mem,
+    System.Mem.StableName as Rebase.System.Mem.StableName,
+    System.Mem.Weak as Rebase.System.Mem.Weak,
+    System.Posix.Internals as Rebase.System.Posix.Internals,
+    System.Posix.Types as Rebase.System.Posix.Types,
+    System.Timeout as Rebase.System.Timeout,
+    Text.ParserCombinators.ReadP as Rebase.Text.ParserCombinators.ReadP,
+    Text.ParserCombinators.ReadPrec as Rebase.Text.ParserCombinators.ReadPrec,
+    Text.Printf as Rebase.Text.Printf,
+    Text.Read as Rebase.Text.Read,
+    Text.Read.Lex as Rebase.Text.Read.Lex,
+    Text.Show as Rebase.Text.Show,
+    Unsafe.Coerce as Rebase.Unsafe.Coerce,
 
   build-depends:
     , base >=4.13 && <5


### PR DESCRIPTION
This is the analog of https://github.com/nikita-volkov/rerebase/pull/5 for `rebase`.  It's a bit more complicated since a few modules were customized, and in particular the Prelude has to import reexports differently.

I've tested it out, and it has functioned exactly the same.  And there's a lot less compilation in the logs, 4 modules instead of hundreds.